### PR TITLE
fix: suppress missing receiver bridge errors

### DIFF
--- a/src/utils/AsyncChromeMessageManager.ts
+++ b/src/utils/AsyncChromeMessageManager.ts
@@ -28,9 +28,17 @@ export default class AsyncChromeMessageManager {
 
   private forwardMessagesFromWebpageToPopup() {
     window.addEventListener("message", (event) => {
-      if (event.source === window && event.origin === window.location.origin && event.data.source === 'Wppconnect') {
+      if (
+        event.source === window &&
+        event.origin === window.location.origin &&
+        event.data.source === 'Wppconnect' &&
+        typeof event.data.type === 'string' &&
+        event.data.type.endsWith('_RESPONSE')
+      ) {
         void chrome.runtime.sendMessage(event.data).catch((error) => {
-          console.error('Wppconnect.AsyncChromeMessageManager.forwardMessagesFromWebpageToPopup', error, event);
+          if (!this.isReceivingEndError(error)) {
+            console.error('Wppconnect.AsyncChromeMessageManager.forwardMessagesFromWebpageToPopup', error, event);
+          }
           return;
         });
       }
@@ -74,7 +82,11 @@ export default class AsyncChromeMessageManager {
       if (message.source === 'Wppconnect' && message.type === type) {
         try {
           const response = await handler(message.payload);
-          void chrome.runtime.sendMessage({ source: 'Wppconnect', type: `${type}_RESPONSE`, payload: response });
+          void chrome.runtime.sendMessage({ source: 'Wppconnect', type: `${type}_RESPONSE`, payload: response }).catch((error) => {
+            if (!this.isReceivingEndError(error)) {
+              console.error(`Wppconnect.AsyncChromeMessageManager.addExtensionMessageHandler ${type}_RESPONSE`, error);
+            }
+          });
         } catch (error) {
           console.error(`Wppconnect.AsyncChromeMessageManager.addExtensionMessageHandler ${type}_RESPONSE`, error);
         }
@@ -169,5 +181,10 @@ export default class AsyncChromeMessageManager {
         reject(error instanceof Error ? error : new Error(String(error)));
       });
     }
+  }
+
+  private isReceivingEndError(error: unknown) {
+    const message = error instanceof Error ? error.message : String(error);
+    return message.includes('Receiving end does not exist') || message.includes('Could not establish connection');
   }
 }


### PR DESCRIPTION
## Resumo
- Evita o erro ruidoso `Could not establish connection. Receiving end does not exist` no console do WhatsApp Web quando o popup não está aberto.
- O content script agora só encaminha mensagens `*_RESPONSE` da página para o runtime, que são as respostas que o popup realmente precisa.
- Respostas enviadas sem receptor também ignoram o caso esperado de `Receiving end does not exist`, mas continuam logando erros inesperados.

## Validação
- `npm run build`
- parse JSON dos locales `en` e `pt_BR`
- `npm audit --omit=dev --audit-level=high`
- `git diff --check`