### PR TITLE
feat: refresh executions dashboard UI

### DIFF
--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -424,5 +424,169 @@
     "wajsLabPlaceholderResult": {
         "message": "Run an action to see the WA-JS response.",
         "description": "WA-JS result placeholder"
+    },
+    "dashboardTitle": {
+        "message": "WA Executions",
+        "description": "Popup dashboard title"
+    },
+    "dashboardSubtitle": {
+        "message": "Automate WhatsApp functions",
+        "description": "Popup dashboard subtitle"
+    },
+    "executionsTabLabel": {
+        "message": "Executions",
+        "description": "Executions tab label"
+    },
+    "historyTabLabel": {
+        "message": "History",
+        "description": "History tab label"
+    },
+    "newExecutionTitle": {
+        "message": "New execution",
+        "description": "New execution section title"
+    },
+    "newExecutionSubtitle": {
+        "message": "Select a function to run on WhatsApp",
+        "description": "New execution section subtitle"
+    },
+    "selectFunctionLabel": {
+        "message": "Select function",
+        "description": "Function selector placeholder"
+    },
+    "executeButtonLabel": {
+        "message": "Execute",
+        "description": "Execute action button"
+    },
+    "quickExecutionsTitle": {
+        "message": "Quick executions",
+        "description": "Quick executions section title"
+    },
+    "summaryTitle": {
+        "message": "Summary",
+        "description": "Summary section title"
+    },
+    "latestExecutionsTitle": {
+        "message": "Latest executions",
+        "description": "Latest executions section title"
+    },
+    "viewAllLabel": {
+        "message": "View all",
+        "description": "View all link"
+    },
+    "whatsappConnectedLabel": {
+        "message": "WhatsApp connected",
+        "description": "Connected status label"
+    },
+    "whatsappNeedsConnectionLabel": {
+        "message": "Check WhatsApp connection",
+        "description": "Disconnected status label"
+    },
+    "checkConnectionLabel": {
+        "message": "Check connection",
+        "description": "Refresh connection label"
+    },
+    "contactsHelperLabel": {
+        "message": "Paste contacts separated by comma, semicolon or line break.",
+        "description": "Contacts helper text"
+    },
+    "todaySentLabel": {
+        "message": "Sent today",
+        "description": "Sent today summary metric"
+    },
+    "duplicatesTodayLabel": {
+        "message": "Duplicates",
+        "description": "Duplicate contacts summary metric"
+    },
+    "completedThisMonthLabel": {
+        "message": "Completed",
+        "description": "Completed this month summary metric"
+    },
+    "noRecentExecutionsLabel": {
+        "message": "No recent executions yet.",
+        "description": "Empty recent executions label"
+    },
+    "noFunctionSelectedLabel": {
+        "message": "Choose a function before running.",
+        "description": "No function selected error"
+    },
+    "functionSendMessageLabel": {
+        "message": "Send message",
+        "description": "Send message function label"
+    },
+    "functionArchiveChatsLabel": {
+        "message": "Archive chats",
+        "description": "Archive chats function label"
+    },
+    "functionListChatsLabel": {
+        "message": "List chats",
+        "description": "List chats function label"
+    },
+    "functionUnreadChatsLabel": {
+        "message": "Unread chats",
+        "description": "Unread chats function label"
+    },
+    "functionVerifyNumberLabel": {
+        "message": "Verify number",
+        "description": "Verify number function label"
+    },
+    "functionDiagnosticsLabel": {
+        "message": "Connection diagnostics",
+        "description": "Diagnostics function label"
+    },
+    "functionActiveChatLabel": {
+        "message": "Active chat",
+        "description": "Active chat function label"
+    },
+    "functionOpenChatLabel": {
+        "message": "Open chat",
+        "description": "Open chat function label"
+    },
+    "functionMarkReadLabel": {
+        "message": "Mark read",
+        "description": "Mark read function label"
+    },
+    "functionMarkUnreadLabel": {
+        "message": "Mark unread",
+        "description": "Mark unread function label"
+    },
+    "functionPinChatLabel": {
+        "message": "Pin chat",
+        "description": "Pin chat function label"
+    },
+    "functionMuteChatLabel": {
+        "message": "Mute chat",
+        "description": "Mute chat function label"
+    },
+    "functionSendTextLabel": {
+        "message": "Send text",
+        "description": "Send text function label"
+    },
+    "functionSendMessageDescription": {
+        "message": "For contacts or lists",
+        "description": "Send message quick action description"
+    },
+    "functionArchiveChatsDescription": {
+        "message": "Archive non-archived chats",
+        "description": "Archive chats quick action description"
+    },
+    "functionListChatsDescription": {
+        "message": "Inspect available chats",
+        "description": "List chats quick action description"
+    },
+    "functionVerifyNumberDescription": {
+        "message": "Check contact existence",
+        "description": "Verify number quick action description"
+    },
+    "functionRequiresChatLabel": {
+        "message": "Chat ID or phone",
+        "description": "Chat target field label"
+    },
+    "functionRequiresContactLabel": {
+        "message": "Contact ID or phone",
+        "description": "Contact target field label"
+    },
+    "functionRequiresTextLabel": {
+        "message": "Message text",
+        "description": "Action text field label"
     }
 }

--- a/public/_locales/pt_BR/messages.json
+++ b/public/_locales/pt_BR/messages.json
@@ -424,5 +424,169 @@
     "wajsLabPlaceholderResult": {
         "message": "Execute uma ação para ver a resposta da WA-JS.",
         "description": "Placeholder do resultado WA-JS"
+    },
+    "dashboardTitle": {
+        "message": "WA Execuções",
+        "description": "Título do dashboard do popup"
+    },
+    "dashboardSubtitle": {
+        "message": "Automatize funções no WhatsApp",
+        "description": "Subtítulo do dashboard do popup"
+    },
+    "executionsTabLabel": {
+        "message": "Execuções",
+        "description": "Label da aba de execuções"
+    },
+    "historyTabLabel": {
+        "message": "Histórico",
+        "description": "Label da aba de histórico"
+    },
+    "newExecutionTitle": {
+        "message": "Nova execução",
+        "description": "Título da seção de nova execução"
+    },
+    "newExecutionSubtitle": {
+        "message": "Selecione uma função para executar no WhatsApp",
+        "description": "Subtítulo da seção de nova execução"
+    },
+    "selectFunctionLabel": {
+        "message": "Selecione a função",
+        "description": "Placeholder do seletor de função"
+    },
+    "executeButtonLabel": {
+        "message": "Executar",
+        "description": "Label do botão executar"
+    },
+    "quickExecutionsTitle": {
+        "message": "Execuções rápidas",
+        "description": "Título da seção de execuções rápidas"
+    },
+    "summaryTitle": {
+        "message": "Resumo",
+        "description": "Título da seção de resumo"
+    },
+    "latestExecutionsTitle": {
+        "message": "Últimas execuções",
+        "description": "Título da seção de últimas execuções"
+    },
+    "viewAllLabel": {
+        "message": "Ver todas",
+        "description": "Link para ver todas"
+    },
+    "whatsappConnectedLabel": {
+        "message": "WhatsApp conectado",
+        "description": "Label de status conectado"
+    },
+    "whatsappNeedsConnectionLabel": {
+        "message": "Verificar conexão do WhatsApp",
+        "description": "Label de status desconectado"
+    },
+    "checkConnectionLabel": {
+        "message": "Verificar conexão",
+        "description": "Label de atualizar conexão"
+    },
+    "contactsHelperLabel": {
+        "message": "Cole contatos separados por vírgula, ponto e vírgula ou quebra de linha.",
+        "description": "Texto de ajuda dos contatos"
+    },
+    "todaySentLabel": {
+        "message": "Enviadas hoje",
+        "description": "Métrica de envios de hoje"
+    },
+    "duplicatesTodayLabel": {
+        "message": "Duplicadas",
+        "description": "Métrica de duplicadas"
+    },
+    "completedThisMonthLabel": {
+        "message": "Concluídas",
+        "description": "Métrica de concluídas no mês"
+    },
+    "noRecentExecutionsLabel": {
+        "message": "Nenhuma execução recente ainda.",
+        "description": "Estado vazio de execuções recentes"
+    },
+    "noFunctionSelectedLabel": {
+        "message": "Escolha uma função antes de executar.",
+        "description": "Erro de função não selecionada"
+    },
+    "functionSendMessageLabel": {
+        "message": "Enviar mensagem",
+        "description": "Label da função enviar mensagem"
+    },
+    "functionArchiveChatsLabel": {
+        "message": "Arquivar chats",
+        "description": "Label da função arquivar chats"
+    },
+    "functionListChatsLabel": {
+        "message": "Listar chats",
+        "description": "Label da função listar chats"
+    },
+    "functionUnreadChatsLabel": {
+        "message": "Chats não lidos",
+        "description": "Label da função chats não lidos"
+    },
+    "functionVerifyNumberLabel": {
+        "message": "Verificar número",
+        "description": "Label da função verificar número"
+    },
+    "functionDiagnosticsLabel": {
+        "message": "Diagnóstico de conexão",
+        "description": "Label da função diagnóstico"
+    },
+    "functionActiveChatLabel": {
+        "message": "Chat ativo",
+        "description": "Label da função chat ativo"
+    },
+    "functionOpenChatLabel": {
+        "message": "Abrir chat",
+        "description": "Label da função abrir chat"
+    },
+    "functionMarkReadLabel": {
+        "message": "Marcar lido",
+        "description": "Label da função marcar lido"
+    },
+    "functionMarkUnreadLabel": {
+        "message": "Marcar não lido",
+        "description": "Label da função marcar não lido"
+    },
+    "functionPinChatLabel": {
+        "message": "Fixar chat",
+        "description": "Label da função fixar chat"
+    },
+    "functionMuteChatLabel": {
+        "message": "Silenciar chat",
+        "description": "Label da função silenciar chat"
+    },
+    "functionSendTextLabel": {
+        "message": "Enviar texto",
+        "description": "Label da função enviar texto"
+    },
+    "functionSendMessageDescription": {
+        "message": "Para contatos ou listas",
+        "description": "Descrição da ação rápida enviar mensagem"
+    },
+    "functionArchiveChatsDescription": {
+        "message": "Arquivar não arquivados",
+        "description": "Descrição da ação rápida arquivar chats"
+    },
+    "functionListChatsDescription": {
+        "message": "Inspecionar chats",
+        "description": "Descrição da ação rápida listar chats"
+    },
+    "functionVerifyNumberDescription": {
+        "message": "Checar existência",
+        "description": "Descrição da ação rápida verificar número"
+    },
+    "functionRequiresChatLabel": {
+        "message": "Chat ID ou telefone",
+        "description": "Label do campo de alvo do chat"
+    },
+    "functionRequiresContactLabel": {
+        "message": "Contato ID ou telefone",
+        "description": "Label do campo de alvo do contato"
+    },
+    "functionRequiresTextLabel": {
+        "message": "Texto da mensagem",
+        "description": "Label do campo de texto da ação"
     }
 }

--- a/src/components/atoms/Button.tsx
+++ b/src/components/atoms/Button.tsx
@@ -1,7 +1,7 @@
 import React, { ButtonHTMLAttributes, Component, ReactNode } from 'react';
 
 interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
-    variant?: 'primary' | 'secondary' | 'success' | 'danger' | 'warning' | 'info' | 'light' | 'dark';
+    variant?: 'primary' | 'secondary' | 'success' | 'danger' | 'warning' | 'info' | 'light' | 'dark' | 'glass' | 'ghost';
     icon?: ReactNode;
 }
 
@@ -45,17 +45,12 @@ export default class Button extends Component<ButtonProps, {}> {
             case 'secondary':
                 classNames.push(
                     'border',
-                    'border-slate-300',
-                    'bg-white',
-                    'text-slate-700',
-                    'shadow-sm',
-                    'hover:border-slate-400',
-                    'hover:bg-slate-50',
-                    'dark:border-slate-700',
-                    'dark:bg-slate-900',
-                    'dark:text-slate-100',
-                    'dark:hover:border-slate-600',
-                    'dark:hover:bg-slate-800',
+                    'border-white/10',
+                    'bg-white/5',
+                    'text-slate-100',
+                    'shadow-[inset_0_1px_0_rgba(255,255,255,.05)]',
+                    'hover:border-white/20',
+                    'hover:bg-white/10',
                     'focus-visible:ring-slate-400'
                 );
                 break;
@@ -93,12 +88,10 @@ export default class Button extends Component<ButtonProps, {}> {
                 break;
             case 'light':
                 classNames.push(
-                    'bg-slate-100',
-                    'text-slate-700',
-                    'hover:bg-slate-200',
-                    'dark:bg-slate-800',
-                    'dark:text-slate-100',
-                    'dark:hover:bg-slate-700',
+                    'bg-white/5',
+                    'text-slate-300',
+                    'hover:bg-white/10',
+                    'hover:text-white',
                     'focus-visible:ring-slate-400'
                 );
                 break;
@@ -111,6 +104,28 @@ export default class Button extends Component<ButtonProps, {}> {
                     'dark:text-slate-950',
                     'dark:hover:bg-slate-200',
                     'focus-visible:ring-slate-500'
+                );
+                break;
+            case 'glass':
+                classNames.push(
+                    'border',
+                    'border-white/10',
+                    'bg-white/5',
+                    'text-slate-100',
+                    'shadow-[inset_0_1px_0_rgba(255,255,255,.08),0_14px_30px_rgba(0,0,0,.16)]',
+                    'backdrop-blur',
+                    'hover:border-emerald-300/30',
+                    'hover:bg-white/10',
+                    'focus-visible:ring-emerald-400'
+                );
+                break;
+            case 'ghost':
+                classNames.push(
+                    'bg-transparent',
+                    'text-slate-300',
+                    'hover:bg-white/10',
+                    'hover:text-white',
+                    'focus-visible:ring-slate-400'
                 );
                 break;
         }

--- a/src/components/atoms/ControlFactory.tsx
+++ b/src/components/atoms/ControlFactory.tsx
@@ -16,26 +16,23 @@ class ControlFactory {
                 const classNames = ['w-full',
                     'flex-auto',
                     'min-h-[2.75rem]',
-                    'bg-white',
-                    'dark:bg-slate-900',
+                    'bg-slate-950/35',
                     'border',
-                    'border-slate-300',
-                    'dark:border-slate-700',
+                    'border-white/10',
                     'px-3',
                     'py-2',
                     'rounded-lg',
                     'text-sm',
-                    'text-slate-900',
-                    'dark:text-slate-100',
+                    'text-slate-100',
                     'placeholder:text-slate-400',
-                    'dark:placeholder:text-slate-500',
+                    'shadow-[inset_0_1px_0_rgba(255,255,255,.04)]',
+                    'outline-none',
                     'transition-shadow',
                     'ease-in-out',
                     'duration-150',
                     'focus:ring-2',
                     'focus:ring-emerald-500',
-                    'focus:border-emerald-500',
-                    'focus:outline-none'];
+                    'focus:border-emerald-400'];
 
                 if (type === 'input') {
                     return <input {...(props as React.InputHTMLAttributes<HTMLInputElement>)} className={[...classNames, ...(this.props.className || '').split(' ')].join(' ')} />;

--- a/src/components/molecules/Box.tsx
+++ b/src/components/molecules/Box.tsx
@@ -15,31 +15,27 @@ export default class Box extends Component<BoxProps, {}> {
             'mx-auto',
             'flex',
             'flex-col',
-            'bg-white',
-            'dark:bg-slate-950',
-            'dark:text-slate-100',
+            'bg-slate-900/56',
+            'text-slate-100',
             'border',
-            'border-slate-200',
-            'dark:border-slate-800',
-            'shadow-sm',
-            'rounded-lg',
+            'border-white/10',
+            'shadow-[inset_0_1px_0_rgba(255,255,255,.06),0_18px_60px_rgba(0,0,0,.18)]',
+            'backdrop-blur',
+            'rounded-2xl',
             'overflow-hidden',
             ...(this.props.className || '').split(' ')
         ].join(' ')}>
             {(title || headerButtons) && <div className={['p-4',
                 'border-b',
-                'border-slate-200',
-                'dark:border-slate-800',
+                'border-white/10',
                 'flex',
                 'gap-3',
                 'justify-between',
                 'items-center',
-                'bg-slate-50',
-                'dark:bg-slate-900'].join(' ')}>
+                'bg-white/5'].join(' ')}>
                 {title && <h1 className={['text-lg',
                     'font-semibold',
-                    'text-slate-800',
-                    'dark:text-slate-200'].join(' ')}>{title}</h1>}
+                    'text-white'].join(' ')}>{title}</h1>}
                 {headerButtons}
             </div>}
             <div className={[
@@ -55,13 +51,10 @@ export default class Box extends Component<BoxProps, {}> {
             {footer && <div className={['px-4',
                 'py-3',
                 'border-t',
-                'border-slate-200',
-                'dark:border-slate-800',
-                'bg-slate-50',
+                'border-white/10',
+                'bg-white/5',
                 'text-sm',
-                'text-slate-600',
-                'dark:bg-slate-900',
-                'dark:text-slate-300'].join(' ')}>
+                'text-slate-400'].join(' ')}>
                 {footer}
             </div>}
         </section>;

--- a/src/components/molecules/SelectCountryCode.tsx
+++ b/src/components/molecules/SelectCountryCode.tsx
@@ -105,22 +105,19 @@ export default class SelectCountryCode extends Component<{ options?: CountryCode
                         'min-h-[2.75rem]',
                         'rounded-lg',
                         'border',
-                        'border-slate-300',
-                        'bg-white',
+                        'border-white/10',
+                        'bg-slate-950/35',
                         'px-3',
                         'py-2',
                         'text-left',
                         'text-sm',
-                        'text-slate-900',
-                        'shadow-sm',
+                        'text-slate-100',
+                        'shadow-[inset_0_1px_0_rgba(255,255,255,.04)]',
                         'transition',
-                        'hover:border-slate-400',
+                        'hover:border-emerald-400/40',
                         'focus:outline-none',
                         'focus:ring-2',
                         'focus:ring-emerald-500',
-                        'dark:border-slate-700',
-                        'dark:bg-slate-900',
-                        'dark:text-slate-100',
                     ].join(' ')}
                     type="button"
                     onClick={this.toggleOpen}
@@ -132,8 +129,8 @@ export default class SelectCountryCode extends Component<{ options?: CountryCode
                     </span>
                 </button>
                 {isOpen && (
-                    <div className="absolute z-20 mt-2 w-full overflow-hidden rounded-lg border border-slate-200 bg-white shadow-lg dark:border-slate-800 dark:bg-slate-950">
-                        <div className="border-b border-slate-200 p-2 dark:border-slate-800">
+                    <div className="absolute z-20 mt-2 w-full overflow-hidden rounded-lg border border-white/10 bg-slate-950 shadow-2xl">
+                        <div className="border-b border-white/10 p-2">
                             <ControlInput
                                 type="text"
                                 placeholder={this.searchPlaceholder}
@@ -146,7 +143,7 @@ export default class SelectCountryCode extends Component<{ options?: CountryCode
                                 filteredOptions.map((option) => (
                                     <li key={option.value}>
                                         <button
-                                            className={`w-full px-3 py-2 text-left text-sm transition hover:bg-emerald-50 dark:hover:bg-emerald-950 ${selectedValue === option ? 'bg-emerald-100 text-emerald-900 dark:bg-emerald-900 dark:text-emerald-50' : 'text-slate-700 dark:text-slate-200'}`}
+                                            className={`w-full px-3 py-2 text-left text-sm transition hover:bg-emerald-400/10 ${selectedValue === option ? 'bg-emerald-400/15 text-emerald-100' : 'text-slate-200'}`}
                                             type="button"
                                             onClick={() => this.handleSelect(option)}
                                         >

--- a/src/components/organisms/ArchiveForm.tsx
+++ b/src/components/organisms/ArchiveForm.tsx
@@ -49,9 +49,9 @@ export default class ArchiveForm extends Component<{ className?: string }, { arc
             footer={this.archiveFormFooter}>
             <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_10rem]">
                 <label className="flex flex-col gap-2">
-                    <span className="flex items-center justify-between gap-2 text-sm font-semibold text-slate-700 dark:text-slate-200">
+                    <span className="flex items-center justify-between gap-2 text-sm font-semibold text-slate-300">
                         <span>{this.archiveDelayLabel}</span>
-                        <span className="rounded-full bg-slate-100 px-2 py-1 font-mono text-xs text-slate-700 dark:bg-slate-800 dark:text-slate-100">{this.state.archiveDelayMs}ms</span>
+                        <span className="rounded-full bg-white/10 px-2 py-1 font-mono text-xs text-slate-100">{this.state.archiveDelayMs}ms</span>
                     </span>
                     <input
                         type="range"
@@ -60,12 +60,12 @@ export default class ArchiveForm extends Component<{ className?: string }, { arc
                         step={STEP_ARCHIVE_DELAY_MS}
                         value={this.state.archiveDelayMs}
                         onChange={this.handleDelayChange}
-                        className="h-2 w-full cursor-pointer appearance-none rounded-full bg-slate-200 accent-emerald-600 outline-none dark:bg-slate-800"
+                        className="h-2 w-full cursor-pointer appearance-none rounded-full bg-slate-800 accent-emerald-500 outline-none"
                     />
-                    <span className="text-xs text-slate-500 dark:text-slate-400">{this.archiveDelayHelp}</span>
+                    <span className="text-xs text-slate-400">{this.archiveDelayHelp}</span>
                 </label>
                 <label className="flex flex-col gap-2">
-                    <span className="text-sm font-semibold text-slate-700 dark:text-slate-200">ms</span>
+                    <span className="text-sm font-semibold text-slate-300">ms</span>
                     <ControlInput
                         type="number"
                         min={MIN_ARCHIVE_DELAY_MS}

--- a/src/components/organisms/LogTable.tsx
+++ b/src/components/organisms/LogTable.tsx
@@ -39,9 +39,9 @@ export default class LogTable extends Component<{ className?: string }, { logs: 
 
     render() {
         const logLevelClass: { [key: number]: string } = {
-            1: 'border-rose-200 bg-rose-50 text-rose-900 dark:border-rose-900 dark:bg-rose-950 dark:text-rose-100',
-            2: 'border-amber-200 bg-amber-50 text-amber-900 dark:border-amber-900 dark:bg-amber-950 dark:text-amber-100',
-            3: 'border-emerald-200 bg-emerald-50 text-emerald-900 dark:border-emerald-900 dark:bg-emerald-950 dark:text-emerald-100'
+            1: 'border-rose-400/30 bg-rose-500/10 text-rose-100',
+            2: 'border-amber-400/30 bg-amber-400/10 text-amber-100',
+            3: 'border-emerald-400/30 bg-emerald-400/10 text-emerald-100'
         };
 
         return <Box
@@ -59,7 +59,7 @@ export default class LogTable extends Component<{ className?: string }, { logs: 
                     onClick={this.handleClear}
                 >{this.cleanButtonLabel}</Button>
             </div>}>
-            {this.state.logs.length === 0 && <div className="rounded-lg border border-dashed border-slate-300 px-4 py-8 text-center text-sm text-slate-500 dark:border-slate-700 dark:text-slate-400">
+            {this.state.logs.length === 0 && <div className="rounded-lg border border-dashed border-white/12 px-4 py-8 text-center text-sm text-slate-400">
                 {this.emptyLogsLabel}
             </div>}
             {this.state.logs.length > 0 && <div className="overflow-x-auto">

--- a/src/components/organisms/MessageButtonsForm.tsx
+++ b/src/components/organisms/MessageButtonsForm.tsx
@@ -189,11 +189,11 @@ export default class MessageButtonsForm extends Component<{ className?: string }
             className={this.props.className}
             title={this.messageButtonsFormTitle}
             headerButtons={<div className="flex items-center gap-3">
-                <span className="hidden rounded-full bg-slate-100 px-3 py-1 text-xs font-semibold text-slate-600 dark:bg-slate-800 dark:text-slate-300 sm:inline-flex">{buttons.length}/3</span>
+                <span className="hidden rounded-full bg-white/10 px-3 py-1 text-xs font-semibold text-slate-300 sm:inline-flex">{buttons.length}/3</span>
                 <Button variant="secondary" type="button" disabled={buttons.length >= 3} onClick={this.handleAddButton} icon="+">{this.addButtonLabel}</Button>
             </div>}
             footer={<>
-                <p className="mb-2 font-semibold text-amber-700 dark:text-amber-300">{this.importantNoteMessageButtonsForm}</p>
+                <p className="mb-2 font-semibold text-amber-300">{this.importantNoteMessageButtonsForm}</p>
                 <p>{this.listTitleNoteMessageButtonsForm}</p>
                 <ul className="mt-2 list-disc space-y-1 pl-5">
                     <li dangerouslySetInnerHTML={{ __html: this.firstListItemNoteMessageButtonsForm }} />
@@ -201,11 +201,11 @@ export default class MessageButtonsForm extends Component<{ className?: string }
                     <li dangerouslySetInnerHTML={{ __html: this.thirdListItemNoteMessageButtonsForm }} />
                 </ul>
             </>}>
-            <div className="flex items-center justify-between gap-3 rounded-lg border border-slate-200 bg-slate-50 px-3 py-2 text-sm text-slate-600 dark:border-slate-800 dark:bg-slate-900 dark:text-slate-300">
+            <div className="flex items-center justify-between gap-3 rounded-lg border border-white/10 bg-slate-950/35 px-3 py-2 text-sm text-slate-300">
                 <span>{this.buttonLimitLabel}</span>
                 <span className="font-mono">{buttons.length}/3</span>
             </div>
-            {buttons.length === 0 && <div className="rounded-lg border border-dashed border-slate-300 px-4 py-8 text-center text-sm text-slate-500 dark:border-slate-700 dark:text-slate-400">
+            {buttons.length === 0 && <div className="rounded-lg border border-dashed border-white/12 px-4 py-8 text-center text-sm text-slate-400">
                 {this.emptyButtonsLabel}
             </div>}
             {buttons.length > 0 &&
@@ -222,18 +222,16 @@ export default class MessageButtonsForm extends Component<{ className?: string }
                                 'gap-3',
                                 'rounded-lg',
                                 'border',
-                                'border-slate-200',
-                                'bg-white',
+                                'border-white/10',
+                                'bg-slate-950/35',
                                 'p-3',
-                                'shadow-sm',
-                                'dark:border-slate-800',
-                                'dark:bg-slate-950',
+                                'shadow-[inset_0_1px_0_rgba(255,255,255,.04)]',
                                 'lg:grid-cols-[2rem_10rem_minmax(0,1fr)_minmax(0,1fr)_auto]',
                                 index === draggedIndex ? 'ring-2 ring-emerald-400' : '',
                                 index === dropIndex ? 'border-dashed border-emerald-400' : ''
                             ].join(' ')}
                         >
-                            <div className="flex items-center justify-center rounded-md bg-slate-100 text-slate-500 dark:bg-slate-900" title={this.dragButtonLabel}>::</div>
+                            <div className="flex items-center justify-center rounded-md bg-white/10 text-slate-400" title={this.dragButtonLabel}>::</div>
                             <label className="flex flex-col gap-1">
                                 <span className="text-xs font-semibold text-slate-500">{this.typeLabelMessageButtonsForm}</span>
                                 <ControlSelect value={button.type} onChange={event => this.handleTypeChange(event, button.id)}>
@@ -245,7 +243,7 @@ export default class MessageButtonsForm extends Component<{ className?: string }
                             <label className="flex flex-col gap-1">
                                 <span className="text-xs font-semibold text-slate-500">{this.valueLabelMessageButtonsForm}</span>
                                 <ControlInput
-                                    className={button.type === 'id' ? 'bg-slate-50 text-slate-500 dark:bg-slate-900' : ''}
+                                    className={button.type === 'id' ? 'bg-slate-900/80 text-slate-500' : ''}
                                     type={button.type === 'phoneNumber' ? 'tel' : button.type === 'url' ? 'url' : 'text'}
                                     value={button.value}
                                     onChange={event => this.handleValueChange(event, button.id)}
@@ -263,12 +261,12 @@ export default class MessageButtonsForm extends Component<{ className?: string }
                             <Button
                                 variant="light"
                                 type="button"
-                                className="self-end text-rose-700 dark:text-rose-300"
+                                className="self-end text-rose-300"
                                 onClick={() => this.handleDeleteButton(button.id)}
                             >
                                 {this.deleteButtonLabel}
                             </Button>
-                            {pendingDeleteId === button.id && <div className="rounded-lg border border-rose-200 bg-rose-50 p-3 text-sm text-rose-900 dark:border-rose-900/70 dark:bg-rose-950/30 dark:text-rose-100 lg:col-span-5">
+                            {pendingDeleteId === button.id && <div className="rounded-lg border border-rose-400/30 bg-rose-500/10 p-3 text-sm text-rose-100 lg:col-span-5">
                                 <div className="font-semibold">{this.deleteButtonConfirmLabel}</div>
                                 <div className="mt-3 flex justify-end gap-2">
                                     <Button variant="secondary" type="button" onClick={() => this.setState({ pendingDeleteId: null })}>

--- a/src/components/organisms/MessageForm.tsx
+++ b/src/components/organisms/MessageForm.tsx
@@ -119,7 +119,7 @@ export default class MessageForm extends Component<{ className?: string }, { mes
             </>}>
             <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_18rem]">
                 <label className="flex min-h-[14rem] flex-col gap-2">
-                    <span className="text-sm font-semibold text-slate-700 dark:text-slate-200">{this.messageDraftLabel}</span>
+                    <span className="text-sm font-semibold text-slate-300">{this.messageDraftLabel}</span>
                     <ControlTextArea
                         className="min-h-[12rem] resize-y"
                         value={message}
@@ -129,10 +129,10 @@ export default class MessageForm extends Component<{ className?: string }, { mes
                 <div className="flex flex-col gap-3">
                     <label
                         htmlFor="attachment"
-                        className="flex min-h-[12rem] cursor-pointer flex-col items-center justify-center rounded-lg border-2 border-dashed border-slate-300 bg-slate-50 px-4 py-6 text-center transition hover:border-emerald-400 hover:bg-emerald-50 dark:border-slate-700 dark:bg-slate-900 dark:hover:border-emerald-600 dark:hover:bg-emerald-950"
+                        className="flex min-h-[12rem] cursor-pointer flex-col items-center justify-center rounded-lg border-2 border-dashed border-white/10 bg-slate-950/35 px-4 py-6 text-center transition hover:border-emerald-400/60 hover:bg-emerald-400/10"
                     >
-                        <span className="mb-2 flex h-10 w-10 items-center justify-center rounded-full bg-white text-lg font-bold text-emerald-700 shadow-sm dark:bg-slate-950 dark:text-emerald-300">+</span>
-                        <span className="text-sm font-semibold text-slate-800 dark:text-slate-100">
+                        <span className="mb-2 flex h-10 w-10 items-center justify-center rounded-full bg-emerald-400/10 text-lg font-bold text-emerald-300 shadow-sm">+</span>
+                        <span className="text-sm font-semibold text-slate-100">
                             {attachment?.name ? this.selectedAttachmentLabel : this.attachmentLabelMessageForm}
                         </span>
                         {attachment?.name && <span className="mt-1 max-w-full truncate text-xs text-slate-500">{attachment.name}</span>}
@@ -155,9 +155,9 @@ export default class MessageForm extends Component<{ className?: string }, { mes
             </div>
             <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_18rem]">
                 <label className="flex flex-col gap-2">
-                    <span className="flex items-center justify-between gap-2 text-sm font-semibold text-slate-700 dark:text-slate-200">
+                    <span className="flex items-center justify-between gap-2 text-sm font-semibold text-slate-300">
                         <span>{this.delayLabelMessageForm}</span>
-                        <span className="rounded-full bg-slate-100 px-2 py-1 font-mono text-xs text-slate-700 dark:bg-slate-800 dark:text-slate-100">{this.state.delay.toFixed(1)}s</span>
+                        <span className="rounded-full bg-white/10 px-2 py-1 font-mono text-xs text-slate-100">{this.state.delay.toFixed(1)}s</span>
                     </span>
                     <input
                         type="range"
@@ -168,11 +168,11 @@ export default class MessageForm extends Component<{ className?: string }, { mes
                         step="0.1"
                         value={this.state.delay}
                         onChange={(e) => this.setState({ delay: +e.target.value })}
-                        className="h-2 w-full cursor-pointer appearance-none rounded-full bg-slate-200 accent-emerald-600 outline-none dark:bg-slate-800"
+                        className="h-2 w-full cursor-pointer appearance-none rounded-full bg-slate-800 accent-emerald-500 outline-none"
                     />
                 </label>
                 <label className="flex flex-col gap-2">
-                    <span className="text-sm font-semibold text-slate-700 dark:text-slate-200">{this.countryCodePrefixMessageForm}</span>
+                    <span className="text-sm font-semibold text-slate-300">{this.countryCodePrefixMessageForm}</span>
                     <SelectCountryCode />
                 </label>
             </div>

--- a/src/options.tsx
+++ b/src/options.tsx
@@ -13,24 +13,24 @@ class Options extends Component<{}, {}>{
   componentDidMount() {
     const body = document.querySelector('body');
     if (!body) return;
-    body.classList.add('bg-slate-100');
-    body.classList.add('dark:bg-slate-950');
-    body.classList.add('text-slate-900');
-    body.classList.add('dark:text-slate-100');
+    body.classList.add('bg-slate-950');
+    body.classList.add('text-slate-100');
     body.style.minWidth = '48rem';
   }
 
   render() {
-    return <main className="mx-auto flex w-full max-w-6xl flex-col gap-5 px-5 py-6">
-      <header className="flex flex-col gap-1">
-        <p className="text-sm font-semibold uppercase tracking-wide text-emerald-700 dark:text-emerald-300">Wppconnect</p>
-        <h1 className="text-2xl font-bold text-slate-950 dark:text-white">{this.title}</h1>
-        <p className="text-sm text-slate-600 dark:text-slate-300">{this.subtitle}</p>
+    return <main className="min-h-screen bg-[radial-gradient(circle_at_12%_0%,rgba(16,185,129,.20),transparent_30%),linear-gradient(135deg,#0b1220,#111827_54%,#07111c)] px-5 py-6 text-slate-100">
+      <div className="mx-auto flex w-full max-w-6xl flex-col gap-5">
+      <header className="flex flex-col gap-1 rounded-2xl border border-white/10 bg-slate-900/50 px-6 py-5 shadow-[inset_0_1px_0_rgba(255,255,255,.06),0_18px_60px_rgba(0,0,0,.18)]">
+        <p className="text-sm font-semibold uppercase tracking-wide text-emerald-300">Wppconnect</p>
+        <h1 className="text-2xl font-bold text-white">{this.title}</h1>
+        <p className="text-sm text-slate-400">{this.subtitle}</p>
       </header>
       <MessageForm />
       <MessageButtonsForm />
       <ArchiveForm />
       <LogTable />
+      </div>
     </main>;
   }
 }

--- a/src/popup.tsx
+++ b/src/popup.tsx
@@ -1,10 +1,10 @@
-import React, { ChangeEvent, Component, FormEvent, MouseEvent } from 'react';
+import React, { ChangeEvent, Component, FormEvent, MouseEvent, ReactNode } from 'react';
 import { createRoot } from 'react-dom/client';
 import './index.css';
 import Button from './components/atoms/Button';
 import { ControlInput, ControlSelect, ControlTextArea } from './components/atoms/ControlFactory';
-import Box from './components/molecules/Box';
 import ArchiveStatus from './types/ArchiveStatus';
+import Log from './types/Log';
 import QueueStatus from './types/QueueStatus';
 import { WaJsLabAction, WaJsLabResponse } from './types/WaJsLab';
 import AsyncChromeMessageManager from './utils/AsyncChromeMessageManager';
@@ -25,6 +25,22 @@ const createLocalArchiveStatus = (phase: ArchiveStatus['phase'], error?: string)
   error
 });
 
+type PopupTab = 'executions' | 'history';
+type PopupAction =
+  | 'sendMessage'
+  | 'archiveChats'
+  | 'diagnostics'
+  | 'listChats'
+  | 'listUnreadChats'
+  | 'activeChat'
+  | 'queryContact'
+  | 'openChat'
+  | 'markRead'
+  | 'markUnread'
+  | 'pinChat'
+  | 'muteChat'
+  | 'sendText';
+
 type PopupState = {
   contacts: string,
   duplicatedContacts: number,
@@ -33,8 +49,8 @@ type PopupState = {
   confirmed: boolean,
   archiveConfirmOpen: boolean,
   connectionError?: string,
-  mode: 'send' | 'lab',
-  labAction: WaJsLabAction,
+  activeTab: PopupTab,
+  selectedAction: PopupAction | '',
   labChatId: string,
   labContactId: string,
   labText: string,
@@ -43,7 +59,53 @@ type PopupState = {
   labLongitude: string,
   labLoading: boolean,
   labResult?: WaJsLabResponse,
+  logs: Log[],
   activeOperation?: 'send' | 'archive'
+};
+
+type UiIcon =
+  | 'send'
+  | 'archive'
+  | 'settings'
+  | 'clock'
+  | 'check'
+  | 'search'
+  | 'zap'
+  | 'list'
+  | 'user'
+  | 'play'
+  | 'refresh'
+  | 'alert'
+  | 'message'
+  | 'pin';
+
+const Icon = ({ name, className = 'h-5 w-5' }: { name: UiIcon, className?: string }) => {
+  const common = {
+    fill: 'none',
+    stroke: 'currentColor',
+    strokeLinecap: 'round' as const,
+    strokeLinejoin: 'round' as const,
+    strokeWidth: 2
+  };
+
+  const paths: Record<UiIcon, ReactNode> = {
+    send: <><path d="M4 11.5 20 4l-7.5 16-2-7-6.5-1.5Z" /><path d="m11 13 4-4" /></>,
+    archive: <><path d="M4 7h16" /><path d="M6 7v12h12V7" /><path d="M9 11h6" /><path d="m8 4 8 0 1 3H7l1-3Z" /></>,
+    settings: <><path d="M12 15.5a3.5 3.5 0 1 0 0-7 3.5 3.5 0 0 0 0 7Z" /><path d="M19 12a7.8 7.8 0 0 0-.1-1.2l2-1.5-2-3.4-2.4 1a7 7 0 0 0-2-1.1L14 3h-4l-.4 2.8a7 7 0 0 0-2 1.1l-2.4-1-2 3.4 2 1.5A7.8 7.8 0 0 0 5 12c0 .4 0 .8.1 1.2l-2 1.5 2 3.4 2.4-1a7 7 0 0 0 2 1.1L10 21h4l.4-2.8a7 7 0 0 0 2-1.1l2.4 1 2-3.4-2-1.5c.1-.4.2-.8.2-1.2Z" /></>,
+    clock: <><path d="M12 21a9 9 0 1 0 0-18 9 9 0 0 0 0 18Z" /><path d="M12 7v5l3 2" /></>,
+    check: <><path d="M20 6 9 17l-5-5" /></>,
+    search: <><path d="m21 21-4.3-4.3" /><path d="M11 18a7 7 0 1 0 0-14 7 7 0 0 0 0 14Z" /></>,
+    zap: <><path d="M13 2 4 14h7l-1 8 10-13h-7l0-7Z" /></>,
+    list: <><path d="M8 6h13" /><path d="M8 12h13" /><path d="M8 18h13" /><path d="M3 6h.01" /><path d="M3 12h.01" /><path d="M3 18h.01" /></>,
+    user: <><path d="M20 21a8 8 0 0 0-16 0" /><path d="M12 13a5 5 0 1 0 0-10 5 5 0 0 0 0 10Z" /></>,
+    play: <path d="M8 5v14l11-7-11-7Z" />,
+    refresh: <><path d="M21 12a9 9 0 0 1-14.8 6.9" /><path d="M3 12A9 9 0 0 1 17.8 5.1" /><path d="M7 19H3v-4" /><path d="M17 5h4v4" /></>,
+    alert: <><path d="M12 9v4" /><path d="M12 17h.01" /><path d="M10.3 3.9 2.5 18a2 2 0 0 0 1.7 3h15.6a2 2 0 0 0 1.7-3L13.7 3.9a2 2 0 0 0-3.4 0Z" /></>,
+    message: <><path d="M21 15a4 4 0 0 1-4 4H8l-5 3V7a4 4 0 0 1 4-4h10a4 4 0 0 1 4 4v8Z" /></>,
+    pin: <><path d="m15 4 5 5-4 1-4 6-2-2-5 5 5-5-2-2 6-4 1-4Z" /></>
+  };
+
+  return <svg className={className} viewBox="0 0 24 24" aria-hidden="true" {...common}>{paths[name]}</svg>;
 };
 
 class Popup extends Component<{}, PopupState> {
@@ -57,8 +119,8 @@ class Popup extends Component<{}, PopupState> {
       confirmed: true,
       archiveConfirmOpen: false,
       connectionError: undefined,
-      mode: 'send',
-      labAction: 'diagnostics',
+      activeTab: 'executions',
+      selectedAction: '',
       labChatId: '',
       labContactId: '',
       labText: 'Teste WA-JS Lab',
@@ -67,6 +129,7 @@ class Popup extends Component<{}, PopupState> {
       labLongitude: '-46.633308',
       labLoading: false,
       labResult: undefined,
+      logs: [],
       activeOperation: undefined
     };
   }
@@ -91,7 +154,6 @@ class Popup extends Component<{}, PopupState> {
   uniqueContactsLabel = chrome.i18n.getMessage('uniqueContactsLabel') || 'Unique';
   totalContactsLabel = chrome.i18n.getMessage('totalContactsLabel') || 'Total';
   readyToSendLabel = chrome.i18n.getMessage('readyToSendLabel') || 'Ready to send';
-  reviewContactsLabel = chrome.i18n.getMessage('reviewContactsLabel') || 'Review your contacts';
   queueFinishedLabel = chrome.i18n.getMessage('queueFinishedLabel') || 'Queue finished';
   archiveChatsButtonLabel = chrome.i18n.getMessage('archiveChatsButtonLabel') || 'Archive chats';
   archiveChatsConfirmLabel = chrome.i18n.getMessage('archiveChatsConfirmLabel') || 'Archive all non-archived chats?';
@@ -109,35 +171,98 @@ class Popup extends Component<{}, PopupState> {
   archivedChatsLabel = chrome.i18n.getMessage('archivedChatsLabel') || 'Archived';
   archiveFailedLabel = chrome.i18n.getMessage('archiveFailedLabel') || 'Failed';
   archiveCurrentChatLabel = chrome.i18n.getMessage('archiveCurrentChatLabel') || 'Current chat';
-  wajsLabTitle = chrome.i18n.getMessage('wajsLabTitle') || 'WA-JS Lab';
-  wajsLabSubtitle = chrome.i18n.getMessage('wajsLabSubtitle') || 'Run safe WA-JS checks and controlled actions on WhatsApp Web.';
-  wajsLabActionLabel = chrome.i18n.getMessage('wajsLabActionLabel') || 'Action';
-  wajsLabChatLabel = chrome.i18n.getMessage('wajsLabChatLabel') || 'Chat ID or phone';
-  wajsLabContactLabel = chrome.i18n.getMessage('wajsLabContactLabel') || 'Contact ID or phone';
-  wajsLabTextLabel = chrome.i18n.getMessage('wajsLabTextLabel') || 'Text';
-  wajsLabRunLabel = chrome.i18n.getMessage('wajsLabRunLabel') || 'Run action';
   wajsLabResultLabel = chrome.i18n.getMessage('wajsLabResultLabel') || 'Result';
-  wajsLabSendModeLabel = chrome.i18n.getMessage('wajsLabSendModeLabel') || 'Sending';
-  wajsLabLabModeLabel = chrome.i18n.getMessage('wajsLabLabModeLabel') || 'WA-JS Lab';
-  wajsLabQuickChecksLabel = chrome.i18n.getMessage('wajsLabQuickChecksLabel') || 'Quick checks';
-  wajsLabChatActionsLabel = chrome.i18n.getMessage('wajsLabChatActionsLabel') || 'Chat actions';
-  wajsLabMessageActionsLabel = chrome.i18n.getMessage('wajsLabMessageActionsLabel') || 'Message tests';
   wajsLabPlaceholderResult = chrome.i18n.getMessage('wajsLabPlaceholderResult') || 'Run an action to see the WA-JS response.';
+  dashboardTitle = chrome.i18n.getMessage('dashboardTitle') || 'WA Executions';
+  dashboardSubtitle = chrome.i18n.getMessage('dashboardSubtitle') || 'Automate WhatsApp functions';
+  executionsTabLabel = chrome.i18n.getMessage('executionsTabLabel') || 'Executions';
+  historyTabLabel = chrome.i18n.getMessage('historyTabLabel') || 'History';
+  newExecutionTitle = chrome.i18n.getMessage('newExecutionTitle') || 'New execution';
+  newExecutionSubtitle = chrome.i18n.getMessage('newExecutionSubtitle') || 'Select a function to run on WhatsApp';
+  selectFunctionLabel = chrome.i18n.getMessage('selectFunctionLabel') || 'Select function';
+  executeButtonLabel = chrome.i18n.getMessage('executeButtonLabel') || 'Execute';
+  quickExecutionsTitle = chrome.i18n.getMessage('quickExecutionsTitle') || 'Quick executions';
+  summaryTitle = chrome.i18n.getMessage('summaryTitle') || 'Summary';
+  latestExecutionsTitle = chrome.i18n.getMessage('latestExecutionsTitle') || 'Latest executions';
+  viewAllLabel = chrome.i18n.getMessage('viewAllLabel') || 'View all';
+  whatsappConnectedLabel = chrome.i18n.getMessage('whatsappConnectedLabel') || 'WhatsApp connected';
+  whatsappNeedsConnectionLabel = chrome.i18n.getMessage('whatsappNeedsConnectionLabel') || 'Check WhatsApp connection';
+  checkConnectionLabel = chrome.i18n.getMessage('checkConnectionLabel') || 'Check connection';
+  contactsHelperLabel = chrome.i18n.getMessage('contactsHelperLabel') || 'Paste contacts separated by comma, semicolon or line break.';
+  todaySentLabel = chrome.i18n.getMessage('todaySentLabel') || 'Sent today';
+  duplicatesTodayLabel = chrome.i18n.getMessage('duplicatesTodayLabel') || 'Duplicates';
+  completedThisMonthLabel = chrome.i18n.getMessage('completedThisMonthLabel') || 'Completed';
+  noRecentExecutionsLabel = chrome.i18n.getMessage('noRecentExecutionsLabel') || 'No recent executions yet.';
+  noFunctionSelectedLabel = chrome.i18n.getMessage('noFunctionSelectedLabel') || 'Choose a function before running.';
+  functionSendMessageLabel = chrome.i18n.getMessage('functionSendMessageLabel') || 'Send message';
+  functionArchiveChatsLabel = chrome.i18n.getMessage('functionArchiveChatsLabel') || 'Archive chats';
+  functionListChatsLabel = chrome.i18n.getMessage('functionListChatsLabel') || 'List chats';
+  functionUnreadChatsLabel = chrome.i18n.getMessage('functionUnreadChatsLabel') || 'Unread chats';
+  functionVerifyNumberLabel = chrome.i18n.getMessage('functionVerifyNumberLabel') || 'Verify number';
+  functionDiagnosticsLabel = chrome.i18n.getMessage('functionDiagnosticsLabel') || 'Connection diagnostics';
+  functionActiveChatLabel = chrome.i18n.getMessage('functionActiveChatLabel') || 'Active chat';
+  functionOpenChatLabel = chrome.i18n.getMessage('functionOpenChatLabel') || 'Open chat';
+  functionMarkReadLabel = chrome.i18n.getMessage('functionMarkReadLabel') || 'Mark read';
+  functionMarkUnreadLabel = chrome.i18n.getMessage('functionMarkUnreadLabel') || 'Mark unread';
+  functionPinChatLabel = chrome.i18n.getMessage('functionPinChatLabel') || 'Pin chat';
+  functionMuteChatLabel = chrome.i18n.getMessage('functionMuteChatLabel') || 'Mute chat';
+  functionSendTextLabel = chrome.i18n.getMessage('functionSendTextLabel') || 'Send text';
+  functionSendMessageDescription = chrome.i18n.getMessage('functionSendMessageDescription') || 'For contacts or lists';
+  functionArchiveChatsDescription = chrome.i18n.getMessage('functionArchiveChatsDescription') || 'Archive non-archived chats';
+  functionListChatsDescription = chrome.i18n.getMessage('functionListChatsDescription') || 'Inspect available chats';
+  functionVerifyNumberDescription = chrome.i18n.getMessage('functionVerifyNumberDescription') || 'Check contact existence';
+  functionRequiresChatLabel = chrome.i18n.getMessage('functionRequiresChatLabel') || 'Chat ID or phone';
+  functionRequiresContactLabel = chrome.i18n.getMessage('functionRequiresContactLabel') || 'Contact ID or phone';
+  functionRequiresTextLabel = chrome.i18n.getMessage('functionRequiresTextLabel') || 'Message text';
 
   queueStatusListener = 0;
   archiveStatusListener = 0;
+  logListener = 0;
+
+  actions: Array<{ value: PopupAction, label: string, icon: UiIcon, labAction?: WaJsLabAction, needsChat?: boolean, needsContact?: boolean, needsText?: boolean }> = [
+    { value: 'sendMessage', label: this.functionSendMessageLabel, icon: 'send' },
+    { value: 'archiveChats', label: this.functionArchiveChatsLabel, icon: 'archive' },
+    { value: 'diagnostics', label: this.functionDiagnosticsLabel, icon: 'zap', labAction: 'diagnostics' },
+    { value: 'listChats', label: this.functionListChatsLabel, icon: 'list', labAction: 'listChats' },
+    { value: 'listUnreadChats', label: this.functionUnreadChatsLabel, icon: 'message', labAction: 'listUnreadChats' },
+    { value: 'activeChat', label: this.functionActiveChatLabel, icon: 'check', labAction: 'activeChat' },
+    { value: 'queryContact', label: this.functionVerifyNumberLabel, icon: 'search', labAction: 'queryContact', needsContact: true },
+    { value: 'openChat', label: this.functionOpenChatLabel, icon: 'user', labAction: 'openChat', needsChat: true },
+    { value: 'markRead', label: this.functionMarkReadLabel, icon: 'check', labAction: 'markRead', needsChat: true },
+    { value: 'markUnread', label: this.functionMarkUnreadLabel, icon: 'message', labAction: 'markUnread', needsChat: true },
+    { value: 'pinChat', label: this.functionPinChatLabel, icon: 'pin', labAction: 'pinChat', needsChat: true },
+    { value: 'muteChat', label: this.functionMuteChatLabel, icon: 'clock', labAction: 'muteChat', needsChat: true },
+    { value: 'sendText', label: this.functionSendTextLabel, icon: 'send', labAction: 'sendText', needsChat: true, needsText: true }
+  ];
 
   componentDidMount() {
     const body = document.querySelector('body');
     if (!body) return;
-    body.classList.add('bg-slate-100');
-    body.classList.add('dark:bg-slate-950');
-    body.style.minWidth = '26rem';
+    body.classList.add('bg-slate-950');
+    body.classList.add('text-slate-100');
+    body.style.minWidth = '34rem';
 
     this.updateStatus();
     this.updateArchiveStatus();
-    this.queueStatusListener = window.setInterval(this.updateStatus, 250);
-    this.archiveStatusListener = window.setInterval(this.updateArchiveStatus, 250);
+    this.updateLogs();
+    this.queueStatusListener = window.setInterval(this.updateStatus, 500);
+    this.archiveStatusListener = window.setInterval(this.updateArchiveStatus, 500);
+    this.logListener = window.setInterval(this.updateLogs, 2500);
+  }
+
+  componentWillUnmount() {
+    clearInterval(this.queueStatusListener);
+    clearInterval(this.archiveStatusListener);
+    clearInterval(this.logListener);
+  }
+
+  componentDidUpdate(prevProps: Readonly<{}>, prevState: Readonly<PopupState>) {
+    if (!prevState.status?.isProcessing && this.state.status?.isProcessing) {
+      this.setState({ confirmed: false, activeOperation: 'send', activeTab: 'executions' });
+    }
+    if (!prevState.archiveStatus?.isProcessing && this.state.archiveStatus?.isProcessing) {
+      this.setState({ confirmed: false, activeOperation: 'archive', activeTab: 'executions' });
+    }
   }
 
   updateStatus = () => {
@@ -162,18 +287,8 @@ class Popup extends Component<{}, PopupState> {
     });
   }
 
-  componentWillUnmount() {
-    clearInterval(this.queueStatusListener);
-    clearInterval(this.archiveStatusListener);
-  }
-
-  componentDidUpdate(prevProps: Readonly<{}>, prevState: Readonly<PopupState>, snapshot?: any) {
-    if (!prevState.status?.isProcessing && this.state.status?.isProcessing) {
-      this.setState({ confirmed: false, activeOperation: 'send' });
-    }
-    if (!prevState.archiveStatus?.isProcessing && this.state.archiveStatus?.isProcessing) {
-      this.setState({ confirmed: false, activeOperation: 'archive' });
-    }
+  updateLogs = () => {
+    chrome.storage.local.get({ logs: [] }, data => this.setState({ logs: data.logs || [] }));
   }
 
   handleChange = (event: ChangeEvent<HTMLTextAreaElement>) => {
@@ -218,8 +333,7 @@ class Popup extends Component<{}, PopupState> {
     return contacts;
   }
 
-  handleSubmit = (event: FormEvent<HTMLFormElement>) => {
-    event.preventDefault();
+  startSendMessages = () => {
     const language = chrome.i18n.getUILanguage();
     chrome.storage.local.get({ message: this.defaultMessage, attachment: null, buttons: [], delay: 0, prefix: language === 'pt_BR' ? 55 : 0 }, async data => {
       const contacts = this.parseContacts(data.prefix);
@@ -233,8 +347,9 @@ class Popup extends Component<{}, PopupState> {
     });
   }
 
-  handleArchiveChats = () => {
-    this.setState({ archiveConfirmOpen: true });
+  handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    this.startSendMessages();
   }
 
   confirmArchiveChats = () => {
@@ -264,7 +379,7 @@ class Popup extends Component<{}, PopupState> {
     });
   }
 
-  handleOptions = (event: MouseEvent<HTMLButtonElement>) => {
+  handleOptions = (event?: MouseEvent<HTMLButtonElement>) => {
     if (chrome.runtime.openOptionsPage) {
       chrome.runtime.openOptionsPage();
     } else {
@@ -272,39 +387,32 @@ class Popup extends Component<{}, PopupState> {
     }
   }
 
-  labActions: Array<{ value: WaJsLabAction, label: string }> = [
-    { value: 'diagnostics', label: 'Diagnóstico de conexão' },
-    { value: 'profile', label: 'Meu perfil' },
-    { value: 'listChats', label: 'Listar chats' },
-    { value: 'listUnreadChats', label: 'Listar não lidos' },
-    { value: 'activeChat', label: 'Chat ativo' },
-    { value: 'chatMessages', label: 'Mensagens do chat' },
-    { value: 'queryContact', label: 'Consultar contato' },
-    { value: 'contactStatus', label: 'Status do contato' },
-    { value: 'profilePicture', label: 'Foto do contato' },
-    { value: 'businessProfile', label: 'Perfil comercial' },
-    { value: 'commonGroups', label: 'Grupos em comum' },
-    { value: 'openChat', label: 'Abrir chat' },
-    { value: 'markRead', label: 'Marcar lido' },
-    { value: 'markUnread', label: 'Marcar não lido' },
-    { value: 'pinChat', label: 'Fixar chat' },
-    { value: 'unpinChat', label: 'Desfixar chat' },
-    { value: 'muteChat', label: 'Silenciar 1h' },
-    { value: 'unmuteChat', label: 'Remover silêncio' },
-    { value: 'archiveChat', label: 'Arquivar chat' },
-    { value: 'unarchiveChat', label: 'Desarquivar chat' },
-    { value: 'typing', label: 'Typing 5s' },
-    { value: 'recording', label: 'Gravando 5s' },
-    { value: 'pauseTyping', label: 'Pausar typing' },
-    { value: 'setInput', label: 'Preencher input' },
-    { value: 'sendText', label: 'Enviar texto' },
-    { value: 'sendPoll', label: 'Enviar enquete' },
-    { value: 'sendLocation', label: 'Enviar localização' },
-    { value: 'sendVCard', label: 'Enviar vCard' }
-  ];
+  getSelectedAction = () => {
+    return this.actions.find(action => action.value === this.state.selectedAction);
+  }
 
-  runLabAction = (action = this.state.labAction) => {
-    this.setState({ labLoading: true, labAction: action, labResult: undefined });
+  executeSelectedAction = () => {
+    const selectedAction = this.getSelectedAction();
+    if (!selectedAction) {
+      this.setState({ connectionError: this.noFunctionSelectedLabel });
+      return;
+    }
+
+    if (selectedAction.value === 'sendMessage') {
+      this.startSendMessages();
+      return;
+    }
+
+    if (selectedAction.value === 'archiveChats') {
+      this.setState({ archiveConfirmOpen: true, connectionError: undefined });
+      return;
+    }
+
+    if (selectedAction.labAction) this.runLabAction(selectedAction.labAction);
+  }
+
+  runLabAction = (action: WaJsLabAction) => {
+    this.setState({ labLoading: true, labResult: undefined, connectionError: undefined });
     PopupMessageManager.sendMessage(ChromeMessageTypes.WAJS_LAB_EXECUTE, {
       action,
       chatId: this.state.labChatId,
@@ -314,7 +422,7 @@ class Popup extends Component<{}, PopupState> {
       latitude: Number(this.state.labLatitude),
       longitude: Number(this.state.labLongitude)
     }).then((labResult) => {
-      this.setState({ labResult, labLoading: false, connectionError: undefined });
+      this.setState({ labResult, labLoading: false, connectionError: undefined, activeTab: 'history' });
     }).catch((error) => {
       this.setState({
         labLoading: false,
@@ -327,6 +435,17 @@ class Popup extends Component<{}, PopupState> {
           error: error instanceof Error ? error.message : this.whatsappConnectionHelpLabel
         }
       });
+    });
+  }
+
+  selectQuickAction = (action: PopupAction) => {
+    this.setState({
+      selectedAction: action,
+      activeTab: 'executions',
+      archiveConfirmOpen: false,
+      connectionError: undefined
+    }, () => {
+      if (action === 'listChats' || action === 'diagnostics') this.executeSelectedAction();
     });
   }
 
@@ -377,114 +496,117 @@ class Popup extends Component<{}, PopupState> {
     return archiveStatus?.currentChat || this.archiveChatsButtonLabel;
   }
 
-  renderMetric(label: string, value: string | number) {
-    return <div className="rounded-lg border border-slate-200 bg-slate-50 p-3 dark:border-slate-800 dark:bg-slate-900">
-      <div className="text-xs font-semibold uppercase tracking-wide text-slate-500">{label}</div>
-      <div className="mt-1 text-lg font-bold text-slate-900 dark:text-white">{value}</div>
-    </div>;
+  getLogDate = (log: Log) => {
+    if (!log.date) return undefined;
+    const parsed = new Date(log.date);
+    if (!Number.isNaN(parsed.getTime())) return parsed;
+    return undefined;
   }
 
-  renderProgress() {
-    const progress = this.getProgress();
+  getSummary = () => {
+    const now = new Date();
+    const todayKey = now.toDateString();
+    const month = now.getMonth();
+    const year = now.getFullYear();
 
-    return <Box
-      className="w-[26rem]"
-      title={this.state.status?.isProcessing ? this.sendingMessagePopup : this.queueFinishedLabel}
-      footer={this.state.status?.isProcessing ?
-        <Button className="w-full" variant="danger" type="button" onClick={() => PopupMessageManager.sendMessage(ChromeMessageTypes.STOP_QUEUE, undefined)}>{this.cancelButtonLabel}</Button>
-        : <Button className="w-full" variant="primary" type="button" onClick={() => this.setState({ confirmed: true, activeOperation: undefined })}>{this.okButtonLabel}</Button>}>
-      <div className="space-y-4">
-        <div className="rounded-lg border border-slate-200 bg-white p-4 dark:border-slate-800 dark:bg-slate-950">
-          <div className="mb-2 flex items-center justify-between gap-3 text-sm">
-            <span className="font-semibold text-slate-700 dark:text-slate-200">{this.state.status?.isProcessing ? this.sendingPopup : this.readyToSendLabel}</span>
-            <span className="font-mono text-slate-500">{progress}%</span>
-          </div>
-          <div className="h-3 overflow-hidden rounded-full bg-slate-200 dark:bg-slate-800">
-            <div
-              className={`h-full rounded-full progress-bar${this.state.status?.isProcessing ? ' progress-bar-animated' : ''}`}
-              style={{ width: `${progress}%` }}
-            ></div>
-          </div>
-        </div>
-        <div className="grid grid-cols-2 gap-3">
-          {this.renderMetric(this.messageTimePopup, this.formatTime(this.state.status?.elapsedTime || 0))}
-          {this.state.status?.waiting ? this.renderMetric(this.waitingPopup, this.formatTime(this.state.status.waiting)) : this.renderMetric(this.duplicatedContactsPopup, this.state.duplicatedContacts)}
-          {this.renderMetric(this.messagesSentPopup, this.state.status?.processedItems || 0)}
-          {this.renderMetric(this.state.status?.isProcessing ? this.messagesLeftPopup : this.messagesNotSentPopup, this.state.status?.remainingItems || 0)}
-        </div>
+    return this.state.logs.reduce((summary, log) => {
+      const date = this.getLogDate(log);
+      if (log.level === 3 && (!date || date.toDateString() === todayKey)) summary.sentToday += 1;
+      if (log.level === 2 && (!date || date.toDateString() === todayKey)) summary.duplicates += 1;
+      if (log.level === 3 && (!date || date.getMonth() === month && date.getFullYear() === year)) summary.completed += 1;
+      return summary;
+    }, { sentToday: 0, duplicates: 0, completed: 0 });
+  }
+
+  isConnectionHealthy = () => !this.state.connectionError;
+
+  renderShell(children: ReactNode) {
+    return <main className="relative min-h-[38rem] w-[34rem] overflow-hidden bg-[#08111d] text-slate-100 shadow-2xl">
+      <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_20%_8%,rgba(16,185,129,0.20),transparent_28%),radial-gradient(circle_at_90%_12%,rgba(14,165,233,0.16),transparent_30%),linear-gradient(135deg,#0c1624_0%,#111827_55%,#07111c_100%)]"></div>
+      <div className="pointer-events-none absolute inset-0 opacity-[0.09]" style={{ backgroundImage: 'linear-gradient(rgba(255,255,255,.18) 1px, transparent 1px), linear-gradient(90deg, rgba(255,255,255,.18) 1px, transparent 1px)', backgroundSize: '28px 28px' }}></div>
+      <div className="relative flex min-h-[38rem] flex-col">
+        {this.renderHeader()}
+        {children}
+        {this.renderFooter()}
       </div>
-    </Box>;
+    </main>;
   }
 
-  renderArchiveProgress() {
-    const progress = this.getArchiveProgress();
-    const archiveStatus = this.state.archiveStatus;
-    const isIndeterminate = Boolean(archiveStatus?.isProcessing && archiveStatus.totalItems === 0);
-    const progressWidth = isIndeterminate ? '100%' : `${progress}%`;
-    const progressText = isIndeterminate ? '...' : `${progress}%`;
-
-    return <Box
-      className="w-[26rem]"
-      title={this.getArchiveTitle()}
-      footer={archiveStatus?.isProcessing ?
-        <Button className="w-full" variant="danger" type="button" onClick={() => PopupMessageManager.sendMessage(ChromeMessageTypes.STOP_QUEUE, undefined)}>{this.cancelButtonLabel}</Button>
-        : <Button className="w-full" variant="primary" type="button" onClick={() => this.setState({ confirmed: true, activeOperation: undefined })}>{this.okButtonLabel}</Button>}>
-      <div className="space-y-4">
-        <div className={`rounded-lg border p-4 ${archiveStatus?.phase === 'error'
-          ? 'border-rose-200 bg-rose-50 dark:border-rose-900/70 dark:bg-rose-950/30'
-          : 'border-slate-200 bg-white dark:border-slate-800 dark:bg-slate-950'}`}>
-          <div className="mb-2 flex items-center justify-between gap-3 text-sm">
-            <span className={`truncate font-semibold ${archiveStatus?.phase === 'error' ? 'text-rose-700 dark:text-rose-200' : 'text-slate-700 dark:text-slate-200'}`}>
-              {this.getArchiveProgressLabel()}
-            </span>
-            <span className="font-mono text-slate-500">{progressText}</span>
+  renderHeader() {
+    return <header className="px-7 pb-5 pt-7">
+      <div className="flex items-center justify-between gap-4">
+        <div className="flex min-w-0 items-center gap-4">
+          <div className="flex h-14 w-14 shrink-0 items-center justify-center rounded-[1.15rem] bg-emerald-500/10 shadow-[0_0_40px_rgba(16,185,129,0.22)] ring-1 ring-emerald-400/25">
+            <img src="icons/wppconnect64.png" alt="" className="h-12 w-12 rounded-xl" />
           </div>
-          <div className="h-3 overflow-hidden rounded-full bg-slate-200 dark:bg-slate-800">
-            <div
-              className={`h-full rounded-full progress-bar${archiveStatus?.isProcessing ? ' progress-bar-animated' : ''}`}
-              style={{ width: progressWidth }}
-            ></div>
+          <div className="min-w-0">
+            <h1 className="truncate text-[1.55rem] font-extrabold tracking-normal text-white">{this.dashboardTitle}</h1>
+            <p className="truncate text-sm text-slate-400">{this.dashboardSubtitle}</p>
           </div>
         </div>
-        <div className="grid grid-cols-2 gap-3">
-          {this.renderMetric(this.messageTimePopup, this.formatTime(archiveStatus?.elapsedTime || 0))}
-          {archiveStatus?.waiting ? this.renderMetric(this.waitingPopup, this.formatTime(archiveStatus.waiting)) : this.renderMetric(this.archiveFailedLabel, archiveStatus?.failedItems || 0)}
-          {this.renderMetric(this.archivedChatsLabel, archiveStatus?.processedItems || 0)}
-          {this.renderMetric(this.messagesLeftPopup, archiveStatus?.remainingItems || 0)}
-        </div>
-        {archiveStatus?.currentChat && <div className="rounded-lg border border-slate-200 bg-slate-50 p-3 text-xs text-slate-600 dark:border-slate-800 dark:bg-slate-900 dark:text-slate-300">
-          <span className="font-semibold">{this.archiveCurrentChatLabel}: </span>
-          <span className="font-mono">{archiveStatus.currentChat}</span>
-        </div>}
+        <Button
+          type="button"
+          variant="glass"
+          className="shrink-0"
+          onClick={this.handleOptions}
+          icon={<Icon name="settings" className="h-5 w-5" />}
+        >
+          {this.optionsButtonLabel}
+        </Button>
       </div>
-    </Box>;
+      <div className="mt-6 grid grid-cols-2 gap-3 rounded-[1.15rem] bg-slate-950/28 p-2 ring-1 ring-white/7">
+        {this.renderTab('executions', 'zap', this.executionsTabLabel)}
+        {this.renderTab('history', 'clock', this.historyTabLabel)}
+      </div>
+    </header>;
   }
 
-  renderArchiveConfirmation() {
-    if (!this.state.archiveConfirmOpen) return null;
-
-    return <div
-      role="dialog"
-      aria-modal="false"
-      className="rounded-lg border border-amber-200 bg-amber-50 p-4 text-sm text-amber-950 shadow-sm dark:border-amber-900/70 dark:bg-amber-950/30 dark:text-amber-100"
+  renderTab(tab: PopupTab, icon: UiIcon, label: string) {
+    const active = this.state.activeTab === tab;
+    return <button
+      type="button"
+      onClick={() => this.setState({ activeTab: tab })}
+      className={[
+        'inline-flex h-12 items-center justify-center gap-3 rounded-xl text-sm font-bold transition',
+        active
+          ? 'bg-slate-700/72 text-white shadow-[inset_0_1px_0_rgba(255,255,255,.10),0_18px_34px_rgba(0,0,0,.20)]'
+          : 'text-slate-400 hover:bg-white/5 hover:text-slate-100'
+      ].join(' ')}
     >
-      <div className="font-semibold">{this.archiveChatsConfirmLabel}</div>
-      <p className="mt-1 text-xs leading-5 text-amber-900 dark:text-amber-100/80">{this.archiveConfirmDescriptionLabel}</p>
-      <div className="mt-4 flex justify-end gap-2">
-        <Button
-          variant="secondary"
-          type="button"
-          onClick={() => this.setState({ archiveConfirmOpen: false })}
-        >
-          {this.cancelButtonLabel}
-        </Button>
-        <Button
-          variant="warning"
-          type="button"
-          onClick={this.confirmArchiveChats}
-        >
-          {this.archiveConfirmSubmitLabel}
-        </Button>
+      <Icon name={icon} className={active ? 'h-5 w-5 text-emerald-300' : 'h-5 w-5'} />
+      {label}
+    </button>;
+  }
+
+  renderFooter() {
+    const healthy = this.isConnectionHealthy();
+    return <footer className="mt-auto flex items-center justify-between gap-3 border-t border-white/10 px-7 py-4 text-sm text-slate-400">
+      <div className="flex min-w-0 items-center gap-3">
+        <span className={`h-2.5 w-2.5 shrink-0 rounded-full ${healthy ? 'bg-emerald-400 shadow-[0_0_18px_rgba(52,211,153,.85)]' : 'bg-amber-400 shadow-[0_0_18px_rgba(251,191,36,.65)]'}`}></span>
+        <span className="truncate">{healthy ? this.whatsappConnectedLabel : this.whatsappNeedsConnectionLabel}</span>
+      </div>
+      <button type="button" onClick={() => { this.updateStatus(); this.updateArchiveStatus(); }} className="inline-flex shrink-0 items-center gap-2 font-semibold text-slate-400 transition hover:text-emerald-300">
+        {this.checkConnectionLabel}
+        <Icon name="refresh" className="h-4 w-4" />
+      </button>
+    </footer>;
+  }
+
+  renderPanel(children: ReactNode, className = '') {
+    return <section className={`rounded-[1.15rem] border border-white/10 bg-slate-900/48 p-5 shadow-[inset_0_1px_0_rgba(255,255,255,.06),0_18px_60px_rgba(0,0,0,.18)] backdrop-blur ${className}`}>
+      {children}
+    </section>;
+  }
+
+  renderMetric(label: string, value: string | number, icon?: UiIcon, accent = 'text-emerald-300', detail?: string) {
+    return <div className="min-w-0 rounded-xl border border-white/10 bg-slate-800/42 p-4 shadow-[inset_0_1px_0_rgba(255,255,255,.05)]">
+      <div className="flex items-start gap-3">
+        {icon && <div className={`mt-0.5 ${accent}`}><Icon name={icon} className="h-6 w-6" /></div>}
+        <div className="min-w-0">
+          <div className="text-sm leading-5 text-slate-400">{label}</div>
+          <div className="mt-1 text-2xl font-extrabold text-white">{value}</div>
+          {detail && <div className="mt-1 truncate text-xs text-slate-500">{detail}</div>}
+        </div>
       </div>
     </div>;
   }
@@ -492,184 +614,324 @@ class Popup extends Component<{}, PopupState> {
   renderConnectionNotice() {
     if (!this.state.connectionError) return null;
 
-    return <div className="rounded-lg border border-cyan-200 bg-cyan-50 p-3 text-xs leading-5 text-cyan-900 dark:border-cyan-900/70 dark:bg-cyan-950/30 dark:text-cyan-100">
-      <div className="font-semibold">{this.whatsappConnectionHelpLabel}</div>
-      <div className="mt-1 font-mono text-[0.68rem] text-cyan-800 dark:text-cyan-200">{this.state.connectionError}</div>
-    </div>;
-  }
-
-  renderModeSwitch() {
-    return <div className="grid grid-cols-2 gap-2 rounded-lg bg-slate-100 p-1 dark:bg-slate-900">
-      <Button
-        variant={this.state.mode === 'send' ? 'primary' : 'light'}
-        type="button"
-        onClick={() => this.setState({ mode: 'send' })}
-      >
-        {this.wajsLabSendModeLabel}
-      </Button>
-      <Button
-        variant={this.state.mode === 'lab' ? 'primary' : 'light'}
-        type="button"
-        onClick={() => this.setState({ mode: 'lab' })}
-      >
-        {this.wajsLabLabModeLabel}
-      </Button>
-    </div>;
-  }
-
-  renderLabButton(action: WaJsLabAction, label: string, variant: 'secondary' | 'info' | 'warning' = 'secondary') {
-    return <Button
-      variant={variant}
-      type="button"
-      disabled={this.state.labLoading}
-      onClick={() => this.runLabAction(action)}
-    >
-      {label}
-    </Button>;
-  }
-
-  renderLabSection(title: string, actions: Array<[WaJsLabAction, string, ('secondary' | 'info' | 'warning')?]>) {
-    return <div className="space-y-2">
-      <div className="text-xs font-semibold uppercase tracking-wide text-slate-500">{title}</div>
-      <div className="grid grid-cols-2 gap-2">
-        {actions.map(([action, label, variant]) => this.renderLabButton(action, label, variant || 'secondary'))}
+    return <div className="flex gap-3 rounded-xl border border-amber-400/25 bg-amber-400/10 p-3 text-xs leading-5 text-amber-100">
+      <Icon name="alert" className="mt-0.5 h-4 w-4 shrink-0 text-amber-300" />
+      <div className="min-w-0">
+        <div className="font-bold">{this.whatsappConnectionHelpLabel}</div>
+        <div className="mt-1 break-words font-mono text-[0.68rem] text-amber-100/80">{this.state.connectionError}</div>
       </div>
     </div>;
   }
 
-  renderWaJsLab() {
-    const resultText = this.state.labResult ? JSON.stringify(this.state.labResult, null, 2) : this.wajsLabPlaceholderResult;
-
-    return <Box className="w-[34rem]" title={this.wajsLabTitle} footer={this.wajsLabSubtitle}>
-      {this.renderModeSwitch()}
-      {this.renderConnectionNotice()}
-      <div className="grid grid-cols-2 gap-3">
-        <label className="col-span-2 flex flex-col gap-1">
-          <span className="text-xs font-semibold text-slate-500">{this.wajsLabActionLabel}</span>
-          <ControlSelect
-            value={this.state.labAction}
-            onChange={(event) => this.setState({ labAction: event.target.value as WaJsLabAction })}
-          >
-            {this.labActions.map(action => <option key={action.value} value={action.value}>{action.label}</option>)}
-          </ControlSelect>
-        </label>
-        <label className="flex flex-col gap-1">
-          <span className="text-xs font-semibold text-slate-500">{this.wajsLabChatLabel}</span>
-          <ControlInput value={this.state.labChatId} placeholder="5511999999999 ou ...@g.us" onChange={(event) => this.setState({ labChatId: event.target.value })} />
-        </label>
-        <label className="flex flex-col gap-1">
-          <span className="text-xs font-semibold text-slate-500">{this.wajsLabContactLabel}</span>
-          <ControlInput value={this.state.labContactId} placeholder="5511999999999" onChange={(event) => this.setState({ labContactId: event.target.value })} />
-        </label>
-        <label className="col-span-2 flex flex-col gap-1">
-          <span className="text-xs font-semibold text-slate-500">{this.wajsLabTextLabel}</span>
-          <ControlInput value={this.state.labText} onChange={(event) => this.setState({ labText: event.target.value })} />
-        </label>
-        <label className="flex flex-col gap-1">
-          <span className="text-xs font-semibold text-slate-500">Limite</span>
-          <ControlInput type="number" min={1} max={50} value={this.state.labLimit} onChange={(event) => this.setState({ labLimit: +event.target.value })} />
-        </label>
-        <div className="grid grid-cols-2 gap-2">
-          <label className="flex flex-col gap-1">
-            <span className="text-xs font-semibold text-slate-500">Lat</span>
-            <ControlInput value={this.state.labLatitude} onChange={(event) => this.setState({ labLatitude: event.target.value })} />
-          </label>
-          <label className="flex flex-col gap-1">
-            <span className="text-xs font-semibold text-slate-500">Lng</span>
-            <ControlInput value={this.state.labLongitude} onChange={(event) => this.setState({ labLongitude: event.target.value })} />
-          </label>
-        </div>
-      </div>
-      <Button className="w-full" variant="primary" type="button" disabled={this.state.labLoading} onClick={() => this.runLabAction()}>
-        {this.state.labLoading ? this.sendingPopup : this.wajsLabRunLabel}
-      </Button>
-      {this.renderLabSection(this.wajsLabQuickChecksLabel, [
-        ['diagnostics', 'Diagnóstico', 'info'],
-        ['profile', 'Perfil', 'info'],
-        ['listChats', 'Chats', 'info'],
-        ['listUnreadChats', 'Não lidos', 'info'],
-        ['activeChat', 'Ativo', 'info'],
-        ['queryContact', 'Contato', 'info']
-      ])}
-      {this.renderLabSection(this.wajsLabChatActionsLabel, [
-        ['openChat', 'Abrir'],
-        ['chatMessages', 'Mensagens'],
-        ['markRead', 'Lido'],
-        ['markUnread', 'Não lido'],
-        ['pinChat', 'Fixar'],
-        ['unpinChat', 'Desfixar'],
-        ['muteChat', 'Silenciar', 'warning'],
-        ['unmuteChat', 'Som'],
-        ['archiveChat', 'Arquivar', 'warning'],
-        ['unarchiveChat', 'Desarquivar']
-      ])}
-      {this.renderLabSection(this.wajsLabMessageActionsLabel, [
-        ['typing', 'Typing'],
-        ['recording', 'Gravando'],
-        ['pauseTyping', 'Pausar'],
-        ['setInput', 'Input'],
-        ['sendText', 'Texto', 'warning'],
-        ['sendPoll', 'Enquete', 'warning'],
-        ['sendLocation', 'Local', 'warning'],
-        ['sendVCard', 'vCard', 'warning']
-      ])}
-      <div className="rounded-lg border border-slate-200 bg-slate-950 p-3 dark:border-slate-800">
-        <div className="mb-2 text-xs font-semibold uppercase tracking-wide text-slate-400">{this.wajsLabResultLabel}</div>
-        <pre className="max-h-72 overflow-auto whitespace-pre-wrap break-words text-xs leading-5 text-emerald-100">{resultText}</pre>
-      </div>
-    </Box>;
-  }
-
-  renderForm() {
+  renderActionFields() {
+    const selectedAction = this.getSelectedAction();
     const summary = this.getContactSummary();
 
-    return <form onSubmit={this.handleSubmit}>
-      <Box className="w-[26rem]" title={this.reviewContactsLabel} footer={this.prefixFooterNotePopup}>
-        {this.renderModeSwitch()}
-        {this.renderConnectionNotice()}
-        <label className="flex min-h-[13rem] flex-col gap-2">
-          <span className="text-sm font-semibold text-slate-700 dark:text-slate-200">{this.contactsLabel}</span>
+    if (!selectedAction) return null;
+
+    if (selectedAction.value === 'sendMessage') {
+      return <form onSubmit={this.handleSubmit} className="mt-4 space-y-3">
+        <label className="flex flex-col gap-2">
+          <span className="text-sm font-semibold text-slate-300">{this.contactsLabel}</span>
           <ControlTextArea
-            className="min-h-[12rem] resize-none"
+            className="min-h-[8.5rem] resize-none"
             value={this.state.contacts}
             onChange={this.handleChange}
-            placeholder={this.messagePlaceholderPopup}
+            placeholder={this.messagePlaceholderPopup || this.contactsHelperLabel}
             required
           />
         </label>
         <div className="grid grid-cols-3 gap-2">
-          {this.renderMetric(this.totalContactsLabel, summary.total)}
-          {this.renderMetric(this.uniqueContactsLabel, summary.unique)}
-          {this.renderMetric(this.duplicatedContactsPopup, summary.duplicated)}
+          {this.renderMiniMetric(this.totalContactsLabel, summary.total)}
+          {this.renderMiniMetric(this.uniqueContactsLabel, summary.unique)}
+          {this.renderMiniMetric(this.duplicatedContactsPopup, summary.duplicated)}
         </div>
-        <div className="flex gap-2">
-          <Button className="flex-1" variant="primary" type="submit" disabled={summary.unique === 0}>{this.sendButtonLabel}</Button>
-          <Button
-            variant="secondary"
-            type="button"
-            onClick={this.handleOptions}
+        <p className="text-xs leading-5 text-slate-500">{this.prefixFooterNotePopup}</p>
+      </form>;
+    }
+
+    return <div className="mt-4 grid grid-cols-2 gap-3">
+      {selectedAction.needsChat && <label className="col-span-2 flex flex-col gap-2">
+        <span className="text-sm font-semibold text-slate-300">{this.functionRequiresChatLabel}</span>
+        <ControlInput value={this.state.labChatId} placeholder="5511999999999 ou ...@g.us" onChange={(event) => this.setState({ labChatId: event.target.value })} />
+      </label>}
+      {selectedAction.needsContact && <label className="col-span-2 flex flex-col gap-2">
+        <span className="text-sm font-semibold text-slate-300">{this.functionRequiresContactLabel}</span>
+        <ControlInput value={this.state.labContactId} placeholder="5511999999999" onChange={(event) => this.setState({ labContactId: event.target.value })} />
+      </label>}
+      {selectedAction.needsText && <label className="col-span-2 flex flex-col gap-2">
+        <span className="text-sm font-semibold text-slate-300">{this.functionRequiresTextLabel}</span>
+        <ControlInput value={this.state.labText} onChange={(event) => this.setState({ labText: event.target.value })} />
+      </label>}
+    </div>;
+  }
+
+  renderMiniMetric(label: string, value: string | number) {
+    return <div className="rounded-xl border border-white/10 bg-slate-950/36 p-3">
+      <div className="truncate text-[0.68rem] font-bold uppercase text-slate-500">{label}</div>
+      <div className="mt-1 text-lg font-extrabold text-white">{value}</div>
+    </div>;
+  }
+
+  renderArchiveConfirmation() {
+    if (!this.state.archiveConfirmOpen) return null;
+
+    return <div role="dialog" aria-modal="false" className="mt-4 rounded-xl border border-amber-400/30 bg-amber-400/10 p-4 text-sm text-amber-50">
+      <div className="flex gap-3">
+        <Icon name="archive" className="h-5 w-5 shrink-0 text-amber-300" />
+        <div>
+          <div className="font-extrabold">{this.archiveChatsConfirmLabel}</div>
+          <p className="mt-1 text-xs leading-5 text-amber-100/80">{this.archiveConfirmDescriptionLabel}</p>
+        </div>
+      </div>
+      <div className="mt-4 grid grid-cols-2 gap-2">
+        <Button variant="ghost" type="button" onClick={() => this.setState({ archiveConfirmOpen: false })}>
+          {this.cancelButtonLabel}
+        </Button>
+        <Button variant="warning" type="button" onClick={this.confirmArchiveChats}>
+          {this.archiveConfirmSubmitLabel}
+        </Button>
+      </div>
+    </div>;
+  }
+
+  renderNewExecution() {
+    const summary = this.getContactSummary();
+    const sendDisabled = this.state.selectedAction === 'sendMessage' && summary.unique === 0;
+
+    return this.renderPanel(<>
+      <div>
+        <h2 className="text-lg font-extrabold text-white">{this.newExecutionTitle}</h2>
+        <p className="mt-1 text-sm text-slate-400">{this.newExecutionSubtitle}</p>
+      </div>
+      <div className="mt-5">
+        <label className="sr-only" htmlFor="popup-action">{this.selectFunctionLabel}</label>
+        <div className="relative">
+          <Icon name={this.getSelectedAction()?.icon || 'list'} className="pointer-events-none absolute left-4 top-1/2 h-5 w-5 -translate-y-1/2 text-slate-500" />
+          <ControlSelect
+            id="popup-action"
+            className="pl-12"
+            value={this.state.selectedAction}
+            onChange={(event) => this.setState({ selectedAction: event.target.value as PopupAction | '', archiveConfirmOpen: false, connectionError: undefined })}
           >
-            {this.optionsButtonLabel}
+            <option value="">{this.selectFunctionLabel}</option>
+            {this.actions.map(action => <option key={action.value} value={action.value}>{action.label}</option>)}
+          </ControlSelect>
+        </div>
+        {this.renderActionFields()}
+        {this.renderArchiveConfirmation()}
+        {this.renderConnectionNotice()}
+        <Button
+          className="mt-4 w-full"
+          variant="primary"
+          type="button"
+          disabled={this.state.labLoading || sendDisabled}
+          onClick={this.executeSelectedAction}
+          icon={<Icon name="play" className="h-5 w-5" />}
+        >
+          {this.state.labLoading ? this.sendingPopup : this.executeButtonLabel}
+        </Button>
+      </div>
+    </>);
+  }
+
+  renderQuickAction(action: PopupAction, title: string, description: string, icon: UiIcon) {
+    const active = this.state.selectedAction === action;
+    return <button
+      type="button"
+      onClick={() => this.selectQuickAction(action)}
+      className={[
+        'group flex min-h-[8.25rem] flex-col items-center justify-center rounded-xl border p-4 text-center transition',
+        active
+          ? 'border-emerald-400/50 bg-emerald-400/10 shadow-[0_18px_38px_rgba(16,185,129,.12)]'
+          : 'border-white/10 bg-slate-950/22 hover:border-emerald-400/35 hover:bg-white/6'
+      ].join(' ')}
+    >
+      <Icon name={icon} className="h-9 w-9 text-emerald-300 transition group-hover:scale-105" />
+      <div className="mt-4 text-sm font-extrabold text-white">{title}</div>
+      <div className="mt-1 text-xs leading-4 text-slate-400">{description}</div>
+    </button>;
+  }
+
+  renderQuickExecutions() {
+    return this.renderPanel(<>
+      <h2 className="text-lg font-extrabold text-white">{this.quickExecutionsTitle}</h2>
+      <div className="mt-4 grid grid-cols-4 gap-3">
+        {this.renderQuickAction('sendMessage', this.functionSendMessageLabel, this.functionSendMessageDescription, 'send')}
+        {this.renderQuickAction('archiveChats', this.functionArchiveChatsLabel, this.functionArchiveChatsDescription, 'archive')}
+        {this.renderQuickAction('listChats', this.functionListChatsLabel, this.functionListChatsDescription, 'list')}
+        {this.renderQuickAction('queryContact', this.functionVerifyNumberLabel, this.functionVerifyNumberDescription, 'search')}
+      </div>
+    </>);
+  }
+
+  renderSummary() {
+    const summary = this.getSummary();
+
+    return this.renderPanel(<>
+      <h2 className="text-lg font-extrabold text-white">{this.summaryTitle}</h2>
+      <div className="mt-4 grid grid-cols-3 gap-3">
+        {this.renderMetric(this.todaySentLabel, summary.sentToday, 'send', 'text-emerald-300')}
+        {this.renderMetric(this.duplicatesTodayLabel, summary.duplicates, 'alert', 'text-amber-300')}
+        {this.renderMetric(this.completedThisMonthLabel, summary.completed, 'check', 'text-emerald-300')}
+      </div>
+    </>);
+  }
+
+  renderLatestExecutions(limit = 3) {
+    const logs = this.state.logs.slice(-limit).reverse();
+
+    return <section>
+      <div className="mb-3 flex items-center justify-between gap-3">
+        <h2 className="text-lg font-extrabold text-white">{this.latestExecutionsTitle}</h2>
+        <button type="button" onClick={() => this.setState({ activeTab: 'history' })} className="text-sm font-bold text-emerald-300 transition hover:text-emerald-200">
+          {this.viewAllLabel}
+        </button>
+      </div>
+      <div className="space-y-2">
+        {logs.length === 0 && <div className="rounded-xl border border-dashed border-white/12 bg-slate-900/32 p-5 text-center text-sm text-slate-400">{this.noRecentExecutionsLabel}</div>}
+        {logs.map((log, index) => this.renderHistoryRow(log, index))}
+      </div>
+    </section>;
+  }
+
+  renderHistoryRow(log: Log, index: number) {
+    const isSuccess = log.level === 3;
+    const isWarning = log.level === 2;
+    const icon: UiIcon = isSuccess ? 'check' : isWarning ? 'alert' : 'message';
+    const color = isSuccess ? 'text-emerald-300 bg-emerald-400/10 ring-emerald-400/25' : isWarning ? 'text-amber-300 bg-amber-400/10 ring-amber-400/25' : 'text-rose-300 bg-rose-400/10 ring-rose-400/25';
+    const badge = isSuccess ? this.readyToSendLabel : isWarning ? this.duplicatedContactsPopup.replace(':', '') : this.messagesNotSentPopup.replace(':', '');
+
+    return <div key={`${log.date}-${log.contact}-${index}`} className="grid grid-cols-[2.5rem_minmax(0,1fr)_auto] items-center gap-3 rounded-xl border border-white/10 bg-slate-800/42 px-4 py-3 shadow-[inset_0_1px_0_rgba(255,255,255,.04)]">
+      <div className={`flex h-9 w-9 items-center justify-center rounded-full ring-1 ${color}`}>
+        <Icon name={icon} className="h-5 w-5" />
+      </div>
+      <div className="min-w-0">
+        <div className="truncate text-sm font-extrabold text-white">{log.message}</div>
+        <div className="truncate text-xs text-slate-400">{log.contact || '-'}</div>
+      </div>
+      <div className="flex items-center gap-3">
+        <span className={`hidden rounded-full px-3 py-1 text-xs font-bold sm:inline ${isSuccess ? 'bg-emerald-400/12 text-emerald-300' : isWarning ? 'bg-amber-400/12 text-amber-300' : 'bg-rose-400/12 text-rose-300'}`}>{badge}</span>
+        <span className="w-20 truncate text-right text-xs text-slate-400">{log.date}</span>
+      </div>
+    </div>;
+  }
+
+  renderExecutions() {
+    return <div className="space-y-5 px-7 pb-6">
+      {this.renderNewExecution()}
+      {this.renderQuickExecutions()}
+      {this.renderSummary()}
+      {this.renderLatestExecutions()}
+      {this.state.labResult && this.renderLabResult()}
+    </div>;
+  }
+
+  renderHistory() {
+    return <div className="space-y-5 px-7 pb-6">
+      {this.state.labResult && this.renderLabResult()}
+      {this.renderPanel(<>
+        <div className="flex items-center justify-between gap-3">
+          <h2 className="text-lg font-extrabold text-white">{this.latestExecutionsTitle}</h2>
+          <Button variant="ghost" type="button" onClick={this.updateLogs} icon={<Icon name="refresh" className="h-4 w-4" />}>
+            {chrome.i18n.getMessage('updateButtonLabel') || 'Update'}
           </Button>
         </div>
-        <Button
-          className="w-full"
-          variant="warning"
-          type="button"
-          onClick={this.handleArchiveChats}
-        >
-          {this.archiveChatsButtonLabel}
+        <div className="mt-4 max-h-[27rem] space-y-2 overflow-auto pr-1">
+          {this.state.logs.length === 0 && <div className="rounded-xl border border-dashed border-white/12 bg-slate-950/30 p-6 text-center text-sm text-slate-400">{this.noRecentExecutionsLabel}</div>}
+          {this.state.logs.slice().reverse().map((log, index) => this.renderHistoryRow(log, index))}
+        </div>
+      </>)}
+    </div>;
+  }
+
+  renderLabResult() {
+    const resultText = this.state.labResult ? JSON.stringify(this.state.labResult, null, 2) : this.wajsLabPlaceholderResult;
+
+    return this.renderPanel(<>
+      <div className="mb-3 flex items-center gap-2 text-sm font-extrabold text-white">
+        <Icon name="zap" className="h-5 w-5 text-emerald-300" />
+        {this.wajsLabResultLabel}
+      </div>
+      <pre className="max-h-72 overflow-auto whitespace-pre-wrap break-words rounded-xl border border-white/10 bg-slate-950/70 p-4 text-xs leading-5 text-emerald-100">{resultText}</pre>
+    </>);
+  }
+
+  renderProgressShell(title: string, label: string, progress: number, metrics: ReactNode, cancel: () => void, done: () => void, isProcessing?: boolean, currentChat?: string) {
+    return this.renderShell(<div className="px-7 pb-6">
+      {this.renderPanel(<>
+        <div className="mb-5 flex items-center justify-between gap-4">
+          <div>
+            <h2 className="text-xl font-extrabold text-white">{title}</h2>
+            <p className="mt-1 max-w-[25rem] truncate text-sm text-slate-400">{label}</p>
+          </div>
+          <span className="font-mono text-sm font-bold text-emerald-300">{progress}%</span>
+        </div>
+        <div className="h-3 overflow-hidden rounded-full bg-slate-950/70 ring-1 ring-white/10">
+          <div
+            className={`h-full rounded-full progress-bar${isProcessing ? ' progress-bar-animated' : ''}`}
+            style={{ width: `${Math.max(progress, isProcessing && progress === 0 ? 8 : progress)}%` }}
+          ></div>
+        </div>
+        {currentChat && <div className="mt-4 rounded-xl border border-white/10 bg-slate-950/40 p-3 text-xs text-slate-300">
+          <span className="font-bold">{this.archiveCurrentChatLabel}: </span>
+          <span className="font-mono">{currentChat}</span>
+        </div>}
+        <div className="mt-5 grid grid-cols-2 gap-3">{metrics}</div>
+        <Button className="mt-5 w-full" variant={isProcessing ? 'danger' : 'primary'} type="button" onClick={isProcessing ? cancel : done}>
+          {isProcessing ? this.cancelButtonLabel : this.okButtonLabel}
         </Button>
-        {this.renderArchiveConfirmation()}
-      </Box>
-    </form>;
+      </>)}
+    </div>);
+  }
+
+  renderSendProgress() {
+    const progress = this.getProgress();
+    const status = this.state.status;
+
+    return this.renderProgressShell(
+      status?.isProcessing ? this.sendingMessagePopup : this.queueFinishedLabel,
+      status?.isProcessing ? this.sendingPopup : this.readyToSendLabel,
+      progress,
+      <>
+        {this.renderMiniMetric(this.messageTimePopup, this.formatTime(status?.elapsedTime || 0))}
+        {status?.waiting ? this.renderMiniMetric(this.waitingPopup, this.formatTime(status.waiting)) : this.renderMiniMetric(this.duplicatedContactsPopup, this.state.duplicatedContacts)}
+        {this.renderMiniMetric(this.messagesSentPopup, status?.processedItems || 0)}
+        {this.renderMiniMetric(status?.isProcessing ? this.messagesLeftPopup : this.messagesNotSentPopup, status?.remainingItems || 0)}
+      </>,
+      () => PopupMessageManager.sendMessage(ChromeMessageTypes.STOP_QUEUE, undefined),
+      () => this.setState({ confirmed: true, activeOperation: undefined }),
+      status?.isProcessing
+    );
+  }
+
+  renderArchiveProgress() {
+    const progress = this.getArchiveProgress();
+    const archiveStatus = this.state.archiveStatus;
+    const isIndeterminate = Boolean(archiveStatus?.isProcessing && archiveStatus.totalItems === 0);
+
+    return this.renderProgressShell(
+      this.getArchiveTitle(),
+      this.getArchiveProgressLabel(),
+      isIndeterminate ? 0 : progress,
+      <>
+        {this.renderMiniMetric(this.messageTimePopup, this.formatTime(archiveStatus?.elapsedTime || 0))}
+        {archiveStatus?.waiting ? this.renderMiniMetric(this.waitingPopup, this.formatTime(archiveStatus.waiting)) : this.renderMiniMetric(this.archiveFailedLabel, archiveStatus?.failedItems || 0)}
+        {this.renderMiniMetric(this.archivedChatsLabel, archiveStatus?.processedItems || 0)}
+        {this.renderMiniMetric(this.messagesLeftPopup, archiveStatus?.remainingItems || 0)}
+      </>,
+      () => PopupMessageManager.sendMessage(ChromeMessageTypes.STOP_QUEUE, undefined),
+      () => this.setState({ confirmed: true, activeOperation: undefined }),
+      archiveStatus?.isProcessing,
+      archiveStatus?.currentChat
+    );
   }
 
   render() {
     if (this.state.activeOperation === 'archive') return this.renderArchiveProgress();
-    if (this.state.activeOperation === 'send' || !this.state.confirmed) return this.renderProgress();
-    if (this.state.mode === 'lab') return this.renderWaJsLab();
-    return this.state.confirmed ? this.renderForm() : this.renderProgress();
+    if (this.state.activeOperation === 'send' || !this.state.confirmed) return this.renderSendProgress();
+
+    return this.renderShell(this.state.activeTab === 'executions' ? this.renderExecutions() : this.renderHistory());
   }
 }
 


### PR DESCRIPTION
## Summary
- Rebuild the popup as a WA Executions dashboard matching the new dark operational UX direction
- Add execution selector, real quick actions, inline archive confirmation, progress screens, summary metrics and recent history
- Refresh shared controls/options styling so settings use the same glass/dark visual system
- Add i18n labels for the new dashboard copy in en and pt_BR

## Validation
- npm run build
- Parsed en and pt_BR locale JSON
- Playwright smoke with stubbed chrome.* for dist/popup.html and dist/options.html