### PR TITLE
feat: expand WA-JS execution suite

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,9 +31,11 @@ updates:
       - dependency-name: "style-loader"
       - dependency-name: "rimraf"
     groups:
-      runtime:
+      wa-js:
         patterns:
           - "@wppconnect/wa-js"
+      runtime:
+        patterns:
           - "react"
           - "react-dom"
       react-types:

--- a/.github/workflows/update-wa-js.yml
+++ b/.github/workflows/update-wa-js.yml
@@ -1,0 +1,59 @@
+name: Update WA-JS
+
+on:
+  schedule:
+    - cron: "30 8 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update:
+    name: Keep WA-JS current
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24.15.0
+
+      - name: Update WA-JS package range
+        run: npx npm-check-updates --upgrade --target latest --filter "@wppconnect/wa-js"
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Validate locale JSON
+        run: |
+          node -e "JSON.parse(require('fs').readFileSync('public/_locales/en/messages.json','utf8'))"
+          node -e "JSON.parse(require('fs').readFileSync('public/_locales/pt_BR/messages.json','utf8'))"
+
+      - name: Build extension
+        run: npm run build
+
+      - name: Remove ignored lockfile
+        run: rm -f package-lock.json
+
+      - name: Create WA-JS update pull request
+        uses: peter-evans/create-pull-request@v8
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "chore: update wa-js"
+          title: "chore: update wa-js"
+          body: |
+            ## Summary
+            - Updates @wppconnect/wa-js to the latest available version.
+            - Validates locale JSON and production build after the update.
+
+            ## Validation
+            - npm install
+            - locale JSON parse check
+            - npm run build
+          branch: chore/update-wa-js
+          delete-branch: true
+          labels: dependencies,wa-js

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "url": "git+https://github.com/wppconnect-team/wppconnect-extension.git"
   },
   "dependencies": {
-    "@wppconnect/wa-js": "^4.0.0",
+    "@wppconnect/wa-js": "^4.3.1",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
     "scheduler": "^0.27.0"

--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -510,7 +510,7 @@
         "description": "No function selected error"
     },
     "functionSendMessageLabel": {
-        "message": "Send message",
+        "message": "Bulk message",
         "description": "Send message function label"
     },
     "functionArchiveChatsLabel": {
@@ -588,5 +588,141 @@
     "functionRequiresTextLabel": {
         "message": "Message text",
         "description": "Action text field label"
+    },
+    "bulkCaptureTargetsLabel": {
+        "message": "Capture chats/contacts",
+        "description": "Button to capture bulk targets from WhatsApp"
+    },
+    "bulkSpamWarningLabel": {
+        "message": "WhatsApp is increasingly strict with exaggerated spam. Use conservative volumes, consented contacts and realistic delays.",
+        "description": "Bulk sending spam warning"
+    },
+    "deliveryModeLabel": {
+        "message": "Delivery",
+        "description": "Delivery mode label"
+    },
+    "sendNowLabel": {
+        "message": "Send now",
+        "description": "Send now option"
+    },
+    "scheduleMessageLabel": {
+        "message": "Schedule",
+        "description": "Schedule message option"
+    },
+    "scheduleDateLabel": {
+        "message": "Date and time",
+        "description": "Schedule date label"
+    },
+    "scheduledQueueLabel": {
+        "message": "Scheduled in the WhatsApp Web tab. Keep it open and connected.",
+        "description": "Schedule runtime warning"
+    },
+    "allWaJsFunctionsLabel": {
+        "message": "All WA-JS functions",
+        "description": "Advanced WA-JS function executor label"
+    },
+    "allWaJsFunctionsDescription": {
+        "message": "Select any runtime WPP function",
+        "description": "Advanced WA-JS function executor description"
+    },
+    "refreshFunctionsLabel": {
+        "message": "Load functions",
+        "description": "Load WA-JS functions button"
+    },
+    "functionPathLabel": {
+        "message": "Function path",
+        "description": "WA-JS function path field"
+    },
+    "functionArgsLabel": {
+        "message": "Arguments JSON array",
+        "description": "WA-JS function args field"
+    },
+    "functionArgsHelpLabel": {
+        "message": "Example: [\"5511999999999@c.us\", {\"count\": 10}]",
+        "description": "WA-JS function args helper"
+    },
+    "functionProfileLabel": {
+        "message": "Profile",
+        "description": "WA-JS profile function label"
+    },
+    "functionContactStatusLabel": {
+        "message": "Contact status",
+        "description": "WA-JS contact status function label"
+    },
+    "functionProfilePictureLabel": {
+        "message": "Contact picture",
+        "description": "WA-JS profile picture function label"
+    },
+    "functionBusinessProfileLabel": {
+        "message": "Business profile",
+        "description": "WA-JS business profile function label"
+    },
+    "functionCommonGroupsLabel": {
+        "message": "Common groups",
+        "description": "WA-JS common groups function label"
+    },
+    "functionUnpinChatLabel": {
+        "message": "Unpin chat",
+        "description": "WA-JS unpin chat function label"
+    },
+    "functionUnmuteChatLabel": {
+        "message": "Unmute chat",
+        "description": "WA-JS unmute chat function label"
+    },
+    "functionArchiveChatLabel": {
+        "message": "Archive chat",
+        "description": "WA-JS archive chat function label"
+    },
+    "functionUnarchiveChatLabel": {
+        "message": "Unarchive chat",
+        "description": "WA-JS unarchive chat function label"
+    },
+    "functionTypingLabel": {
+        "message": "Typing 5s",
+        "description": "WA-JS typing function label"
+    },
+    "functionRecordingLabel": {
+        "message": "Recording 5s",
+        "description": "WA-JS recording function label"
+    },
+    "functionPauseTypingLabel": {
+        "message": "Pause typing",
+        "description": "WA-JS pause typing function label"
+    },
+    "functionSetInputLabel": {
+        "message": "Fill input",
+        "description": "WA-JS set input function label"
+    },
+    "functionSendPollLabel": {
+        "message": "Send poll",
+        "description": "WA-JS send poll function label"
+    },
+    "functionSendLocationLabel": {
+        "message": "Send location",
+        "description": "WA-JS send location function label"
+    },
+    "functionSendVCardLabel": {
+        "message": "Send vCard",
+        "description": "WA-JS send vCard function label"
+    },
+    "languageSettingsTitle": {
+        "message": "Language",
+        "description": "Language settings section title"
+    },
+    "languageSettingsHelp": {
+        "message": "The default follows the browser language. Change it here for extension screens that support manual language preference.",
+        "description": "Language settings help"
+    },
+    "languageAutoLabel": {
+        "message": "Automatic",
+        "description": "Automatic language option"
+    },
+    "languageEnglishLabel": {
+        "message": "English",
+        "description": "English language option"
+    },
+    "languagePortugueseLabel": {
+        "message": "Portuguese (Brazil)",
+        "description": "Portuguese language option"
     }
 }

--- a/public/_locales/pt_BR/messages.json
+++ b/public/_locales/pt_BR/messages.json
@@ -510,7 +510,7 @@
         "description": "Erro de função não selecionada"
     },
     "functionSendMessageLabel": {
-        "message": "Enviar mensagem",
+        "message": "Enviar mensagem em massa",
         "description": "Label da função enviar mensagem"
     },
     "functionArchiveChatsLabel": {
@@ -588,5 +588,141 @@
     "functionRequiresTextLabel": {
         "message": "Texto da mensagem",
         "description": "Label do campo de texto da ação"
+    },
+    "bulkCaptureTargetsLabel": {
+        "message": "Capturar chats/contatos",
+        "description": "Botão para capturar alvos de envio em massa do WhatsApp"
+    },
+    "bulkSpamWarningLabel": {
+        "message": "O WhatsApp está banindo com facilidade envios exagerados de spam. Use volumes conservadores, contatos com consentimento e delays realistas.",
+        "description": "Aviso de spam no envio em massa"
+    },
+    "deliveryModeLabel": {
+        "message": "Envio",
+        "description": "Label do modo de envio"
+    },
+    "sendNowLabel": {
+        "message": "Enviar agora",
+        "description": "Opção enviar agora"
+    },
+    "scheduleMessageLabel": {
+        "message": "Agendar",
+        "description": "Opção agendar mensagem"
+    },
+    "scheduleDateLabel": {
+        "message": "Data e horário",
+        "description": "Label da data de agendamento"
+    },
+    "scheduledQueueLabel": {
+        "message": "Agendado na aba do WhatsApp Web. Mantenha a aba aberta e conectada.",
+        "description": "Aviso de runtime do agendamento"
+    },
+    "allWaJsFunctionsLabel": {
+        "message": "Todas as funções WA-JS",
+        "description": "Label do executor avançado WA-JS"
+    },
+    "allWaJsFunctionsDescription": {
+        "message": "Selecione qualquer função WPP do runtime",
+        "description": "Descrição do executor avançado WA-JS"
+    },
+    "refreshFunctionsLabel": {
+        "message": "Carregar funções",
+        "description": "Botão de carregar funções WA-JS"
+    },
+    "functionPathLabel": {
+        "message": "Caminho da função",
+        "description": "Campo de caminho da função WA-JS"
+    },
+    "functionArgsLabel": {
+        "message": "Argumentos em JSON array",
+        "description": "Campo de argumentos da função WA-JS"
+    },
+    "functionArgsHelpLabel": {
+        "message": "Exemplo: [\"5511999999999@c.us\", {\"count\": 10}]",
+        "description": "Ajuda de argumentos da função WA-JS"
+    },
+    "functionProfileLabel": {
+        "message": "Perfil",
+        "description": "Label da função de perfil WA-JS"
+    },
+    "functionContactStatusLabel": {
+        "message": "Status do contato",
+        "description": "Label da função de status do contato WA-JS"
+    },
+    "functionProfilePictureLabel": {
+        "message": "Foto do contato",
+        "description": "Label da função de foto do contato WA-JS"
+    },
+    "functionBusinessProfileLabel": {
+        "message": "Perfil comercial",
+        "description": "Label da função de perfil comercial WA-JS"
+    },
+    "functionCommonGroupsLabel": {
+        "message": "Grupos em comum",
+        "description": "Label da função de grupos em comum WA-JS"
+    },
+    "functionUnpinChatLabel": {
+        "message": "Desfixar chat",
+        "description": "Label da função desfixar chat WA-JS"
+    },
+    "functionUnmuteChatLabel": {
+        "message": "Remover silêncio",
+        "description": "Label da função remover silêncio WA-JS"
+    },
+    "functionArchiveChatLabel": {
+        "message": "Arquivar chat",
+        "description": "Label da função arquivar chat WA-JS"
+    },
+    "functionUnarchiveChatLabel": {
+        "message": "Desarquivar chat",
+        "description": "Label da função desarquivar chat WA-JS"
+    },
+    "functionTypingLabel": {
+        "message": "Digitando 5s",
+        "description": "Label da função digitando WA-JS"
+    },
+    "functionRecordingLabel": {
+        "message": "Gravando 5s",
+        "description": "Label da função gravando WA-JS"
+    },
+    "functionPauseTypingLabel": {
+        "message": "Pausar digitação",
+        "description": "Label da função pausar digitação WA-JS"
+    },
+    "functionSetInputLabel": {
+        "message": "Preencher input",
+        "description": "Label da função preencher input WA-JS"
+    },
+    "functionSendPollLabel": {
+        "message": "Enviar enquete",
+        "description": "Label da função enviar enquete WA-JS"
+    },
+    "functionSendLocationLabel": {
+        "message": "Enviar localização",
+        "description": "Label da função enviar localização WA-JS"
+    },
+    "functionSendVCardLabel": {
+        "message": "Enviar vCard",
+        "description": "Label da função enviar vCard WA-JS"
+    },
+    "languageSettingsTitle": {
+        "message": "Idioma",
+        "description": "Título da seção de idioma"
+    },
+    "languageSettingsHelp": {
+        "message": "O padrão segue o idioma do navegador. Altere aqui para telas da extensão que respeitam preferência manual de idioma.",
+        "description": "Ajuda da configuração de idioma"
+    },
+    "languageAutoLabel": {
+        "message": "Automático",
+        "description": "Opção de idioma automático"
+    },
+    "languageEnglishLabel": {
+        "message": "Inglês",
+        "description": "Opção de idioma inglês"
+    },
+    "languagePortugueseLabel": {
+        "message": "Português (Brasil)",
+        "description": "Opção de idioma português"
     }
 }

--- a/src/components/organisms/LanguageForm.tsx
+++ b/src/components/organisms/LanguageForm.tsx
@@ -1,0 +1,48 @@
+import React, { ChangeEvent, Component } from 'react';
+import Box from '../molecules/Box';
+
+type Language = 'auto' | 'en' | 'pt_BR';
+
+const browserLanguage = (): Language => chrome.i18n.getUILanguage() === 'pt_BR' ? 'pt_BR' : 'en';
+
+export default class LanguageForm extends Component<{}, { language: Language }>{
+    constructor(props: {}) {
+        super(props);
+        this.state = {
+            language: 'auto'
+        };
+    }
+
+    title = chrome.i18n.getMessage('languageSettingsTitle') || 'Language';
+    help = chrome.i18n.getMessage('languageSettingsHelp') || 'The default follows the browser language. Change it here for extension screens that support manual language preference.';
+    autoLabel = `${chrome.i18n.getMessage('languageAutoLabel') || 'Automatic'} (${browserLanguage()})`;
+    englishLabel = chrome.i18n.getMessage('languageEnglishLabel') || 'English';
+    portugueseLabel = chrome.i18n.getMessage('languagePortugueseLabel') || 'Portuguese (Brazil)';
+
+    componentDidMount() {
+        chrome.storage.local.get({ language: 'auto' }, data => this.setState({ language: data.language || 'auto' }));
+    }
+
+    handleLanguageChange = (event: ChangeEvent<HTMLSelectElement>) => {
+        const language = event.target.value as Language;
+        this.setState({ language });
+        chrome.storage.local.set({ language, resolvedLanguage: language === 'auto' ? browserLanguage() : language });
+    }
+
+    render() {
+        return <Box title={this.title} footer={this.help}>
+            <label className="flex flex-col gap-2">
+                <span className="text-sm font-semibold text-slate-300">{this.title}</span>
+                <select
+                    value={this.state.language}
+                    onChange={this.handleLanguageChange}
+                    className="min-h-[2.75rem] rounded-lg border border-white/10 bg-slate-950/35 px-3 py-2 text-sm text-slate-100 outline-none transition focus:border-emerald-400 focus:ring-2 focus:ring-emerald-500"
+                >
+                    <option value="auto">{this.autoLabel}</option>
+                    <option value="en">{this.englishLabel}</option>
+                    <option value="pt_BR">{this.portugueseLabel}</option>
+                </select>
+            </label>
+        </Box>;
+    }
+}

--- a/src/options.tsx
+++ b/src/options.tsx
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import { createRoot } from 'react-dom/client';
 import './index.css';
 import ArchiveForm from './components/organisms/ArchiveForm';
+import LanguageForm from './components/organisms/LanguageForm';
 import LogTable from './components/organisms/LogTable';
 import MessageButtonsForm from './components/organisms/MessageButtonsForm';
 import MessageForm from './components/organisms/MessageForm';
@@ -26,6 +27,7 @@ class Options extends Component<{}, {}>{
         <h1 className="text-2xl font-bold text-white">{this.title}</h1>
         <p className="text-sm text-slate-400">{this.subtitle}</p>
       </header>
+      <LanguageForm />
       <MessageForm />
       <MessageButtonsForm />
       <ArchiveForm />

--- a/src/popup.tsx
+++ b/src/popup.tsx
@@ -2,7 +2,7 @@ import React, { ChangeEvent, Component, FormEvent, MouseEvent, ReactNode } from 
 import { createRoot } from 'react-dom/client';
 import './index.css';
 import Button from './components/atoms/Button';
-import { ControlInput, ControlSelect, ControlTextArea } from './components/atoms/ControlFactory';
+import { ControlInput, ControlTextArea } from './components/atoms/ControlFactory';
 import ArchiveStatus from './types/ArchiveStatus';
 import Log from './types/Log';
 import QueueStatus from './types/QueueStatus';
@@ -39,7 +39,26 @@ type PopupAction =
   | 'markUnread'
   | 'pinChat'
   | 'muteChat'
-  | 'sendText';
+  | 'sendText'
+  | 'profile'
+  | 'contactStatus'
+  | 'profilePicture'
+  | 'businessProfile'
+  | 'commonGroups'
+  | 'unpinChat'
+  | 'unmuteChat'
+  | 'archiveChat'
+  | 'unarchiveChat'
+  | 'typing'
+  | 'recording'
+  | 'pauseTyping'
+  | 'setInput'
+  | 'sendPoll'
+  | 'sendLocation'
+  | 'sendVCard'
+  | 'allWaJsFunctions';
+
+type DeliveryMode = 'now' | 'scheduled';
 
 type PopupState = {
   contacts: string,
@@ -51,12 +70,18 @@ type PopupState = {
   connectionError?: string,
   activeTab: PopupTab,
   selectedAction: PopupAction | '',
+  actionMenuOpen: boolean,
   labChatId: string,
   labContactId: string,
   labText: string,
   labLimit: number,
   labLatitude: string,
   labLongitude: string,
+  advancedFunctionPath: string,
+  advancedArgsJson: string,
+  availableFunctions: string[],
+  deliveryMode: DeliveryMode,
+  scheduledAt: string,
   labLoading: boolean,
   labResult?: WaJsLabResponse,
   logs: Log[],
@@ -121,12 +146,18 @@ class Popup extends Component<{}, PopupState> {
       connectionError: undefined,
       activeTab: 'executions',
       selectedAction: '',
+      actionMenuOpen: false,
       labChatId: '',
       labContactId: '',
       labText: 'Teste WA-JS Lab',
       labLimit: 10,
       labLatitude: '-23.55052',
       labLongitude: '-46.633308',
+      advancedFunctionPath: '',
+      advancedArgsJson: '[]',
+      availableFunctions: [],
+      deliveryMode: 'now',
+      scheduledAt: '',
       labLoading: false,
       labResult: undefined,
       logs: [],
@@ -194,7 +225,7 @@ class Popup extends Component<{}, PopupState> {
   completedThisMonthLabel = chrome.i18n.getMessage('completedThisMonthLabel') || 'Completed';
   noRecentExecutionsLabel = chrome.i18n.getMessage('noRecentExecutionsLabel') || 'No recent executions yet.';
   noFunctionSelectedLabel = chrome.i18n.getMessage('noFunctionSelectedLabel') || 'Choose a function before running.';
-  functionSendMessageLabel = chrome.i18n.getMessage('functionSendMessageLabel') || 'Send message';
+  functionSendMessageLabel = chrome.i18n.getMessage('functionSendMessageLabel') || 'Bulk message';
   functionArchiveChatsLabel = chrome.i18n.getMessage('functionArchiveChatsLabel') || 'Archive chats';
   functionListChatsLabel = chrome.i18n.getMessage('functionListChatsLabel') || 'List chats';
   functionUnreadChatsLabel = chrome.i18n.getMessage('functionUnreadChatsLabel') || 'Unread chats';
@@ -214,6 +245,35 @@ class Popup extends Component<{}, PopupState> {
   functionRequiresChatLabel = chrome.i18n.getMessage('functionRequiresChatLabel') || 'Chat ID or phone';
   functionRequiresContactLabel = chrome.i18n.getMessage('functionRequiresContactLabel') || 'Contact ID or phone';
   functionRequiresTextLabel = chrome.i18n.getMessage('functionRequiresTextLabel') || 'Message text';
+  bulkCaptureTargetsLabel = chrome.i18n.getMessage('bulkCaptureTargetsLabel') || 'Capture chats/contacts';
+  bulkSpamWarningLabel = chrome.i18n.getMessage('bulkSpamWarningLabel') || 'WhatsApp is increasingly strict with exaggerated spam. Use conservative volumes, consented contacts and realistic delays.';
+  deliveryModeLabel = chrome.i18n.getMessage('deliveryModeLabel') || 'Delivery';
+  sendNowLabel = chrome.i18n.getMessage('sendNowLabel') || 'Send now';
+  scheduleMessageLabel = chrome.i18n.getMessage('scheduleMessageLabel') || 'Schedule';
+  scheduleDateLabel = chrome.i18n.getMessage('scheduleDateLabel') || 'Date and time';
+  scheduledQueueLabel = chrome.i18n.getMessage('scheduledQueueLabel') || 'Scheduled in the WhatsApp Web tab. Keep it open and connected.';
+  allWaJsFunctionsLabel = chrome.i18n.getMessage('allWaJsFunctionsLabel') || 'All WA-JS functions';
+  allWaJsFunctionsDescription = chrome.i18n.getMessage('allWaJsFunctionsDescription') || 'Select any runtime WPP function';
+  refreshFunctionsLabel = chrome.i18n.getMessage('refreshFunctionsLabel') || 'Load functions';
+  functionPathLabel = chrome.i18n.getMessage('functionPathLabel') || 'Function path';
+  functionArgsLabel = chrome.i18n.getMessage('functionArgsLabel') || 'Arguments JSON array';
+  functionArgsHelpLabel = chrome.i18n.getMessage('functionArgsHelpLabel') || 'Example: [\"5511999999999@c.us\", {\"count\": 10}]';
+  functionProfileLabel = chrome.i18n.getMessage('functionProfileLabel') || 'Profile';
+  functionContactStatusLabel = chrome.i18n.getMessage('functionContactStatusLabel') || 'Contact status';
+  functionProfilePictureLabel = chrome.i18n.getMessage('functionProfilePictureLabel') || 'Contact picture';
+  functionBusinessProfileLabel = chrome.i18n.getMessage('functionBusinessProfileLabel') || 'Business profile';
+  functionCommonGroupsLabel = chrome.i18n.getMessage('functionCommonGroupsLabel') || 'Common groups';
+  functionUnpinChatLabel = chrome.i18n.getMessage('functionUnpinChatLabel') || 'Unpin chat';
+  functionUnmuteChatLabel = chrome.i18n.getMessage('functionUnmuteChatLabel') || 'Unmute chat';
+  functionArchiveChatLabel = chrome.i18n.getMessage('functionArchiveChatLabel') || 'Archive chat';
+  functionUnarchiveChatLabel = chrome.i18n.getMessage('functionUnarchiveChatLabel') || 'Unarchive chat';
+  functionTypingLabel = chrome.i18n.getMessage('functionTypingLabel') || 'Typing 5s';
+  functionRecordingLabel = chrome.i18n.getMessage('functionRecordingLabel') || 'Recording 5s';
+  functionPauseTypingLabel = chrome.i18n.getMessage('functionPauseTypingLabel') || 'Pause typing';
+  functionSetInputLabel = chrome.i18n.getMessage('functionSetInputLabel') || 'Fill input';
+  functionSendPollLabel = chrome.i18n.getMessage('functionSendPollLabel') || 'Send poll';
+  functionSendLocationLabel = chrome.i18n.getMessage('functionSendLocationLabel') || 'Send location';
+  functionSendVCardLabel = chrome.i18n.getMessage('functionSendVCardLabel') || 'Send vCard';
 
   queueStatusListener = 0;
   archiveStatusListener = 0;
@@ -223,16 +283,33 @@ class Popup extends Component<{}, PopupState> {
     { value: 'sendMessage', label: this.functionSendMessageLabel, icon: 'send' },
     { value: 'archiveChats', label: this.functionArchiveChatsLabel, icon: 'archive' },
     { value: 'diagnostics', label: this.functionDiagnosticsLabel, icon: 'zap', labAction: 'diagnostics' },
+    { value: 'profile', label: this.functionProfileLabel, icon: 'user', labAction: 'profile' },
     { value: 'listChats', label: this.functionListChatsLabel, icon: 'list', labAction: 'listChats' },
     { value: 'listUnreadChats', label: this.functionUnreadChatsLabel, icon: 'message', labAction: 'listUnreadChats' },
     { value: 'activeChat', label: this.functionActiveChatLabel, icon: 'check', labAction: 'activeChat' },
     { value: 'queryContact', label: this.functionVerifyNumberLabel, icon: 'search', labAction: 'queryContact', needsContact: true },
+    { value: 'contactStatus', label: this.functionContactStatusLabel, icon: 'message', labAction: 'contactStatus', needsContact: true },
+    { value: 'profilePicture', label: this.functionProfilePictureLabel, icon: 'user', labAction: 'profilePicture', needsContact: true },
+    { value: 'businessProfile', label: this.functionBusinessProfileLabel, icon: 'user', labAction: 'businessProfile', needsContact: true },
+    { value: 'commonGroups', label: this.functionCommonGroupsLabel, icon: 'list', labAction: 'commonGroups', needsContact: true },
     { value: 'openChat', label: this.functionOpenChatLabel, icon: 'user', labAction: 'openChat', needsChat: true },
     { value: 'markRead', label: this.functionMarkReadLabel, icon: 'check', labAction: 'markRead', needsChat: true },
     { value: 'markUnread', label: this.functionMarkUnreadLabel, icon: 'message', labAction: 'markUnread', needsChat: true },
     { value: 'pinChat', label: this.functionPinChatLabel, icon: 'pin', labAction: 'pinChat', needsChat: true },
+    { value: 'unpinChat', label: this.functionUnpinChatLabel, icon: 'pin', labAction: 'unpinChat', needsChat: true },
     { value: 'muteChat', label: this.functionMuteChatLabel, icon: 'clock', labAction: 'muteChat', needsChat: true },
-    { value: 'sendText', label: this.functionSendTextLabel, icon: 'send', labAction: 'sendText', needsChat: true, needsText: true }
+    { value: 'unmuteChat', label: this.functionUnmuteChatLabel, icon: 'clock', labAction: 'unmuteChat', needsChat: true },
+    { value: 'archiveChat', label: this.functionArchiveChatLabel, icon: 'archive', labAction: 'archiveChat', needsChat: true },
+    { value: 'unarchiveChat', label: this.functionUnarchiveChatLabel, icon: 'archive', labAction: 'unarchiveChat', needsChat: true },
+    { value: 'typing', label: this.functionTypingLabel, icon: 'message', labAction: 'typing', needsChat: true },
+    { value: 'recording', label: this.functionRecordingLabel, icon: 'message', labAction: 'recording', needsChat: true },
+    { value: 'pauseTyping', label: this.functionPauseTypingLabel, icon: 'message', labAction: 'pauseTyping', needsChat: true },
+    { value: 'setInput', label: this.functionSetInputLabel, icon: 'message', labAction: 'setInput', needsText: true },
+    { value: 'sendText', label: this.functionSendTextLabel, icon: 'send', labAction: 'sendText', needsChat: true, needsText: true },
+    { value: 'sendPoll', label: this.functionSendPollLabel, icon: 'send', labAction: 'sendPoll', needsChat: true, needsText: true },
+    { value: 'sendLocation', label: this.functionSendLocationLabel, icon: 'send', labAction: 'sendLocation', needsChat: true },
+    { value: 'sendVCard', label: this.functionSendVCardLabel, icon: 'send', labAction: 'sendVCard', needsChat: true, needsContact: true, needsText: true },
+    { value: 'allWaJsFunctions', label: this.allWaJsFunctionsLabel, icon: 'zap', labAction: 'executeFunction' }
   ];
 
   componentDidMount() {
@@ -338,9 +415,12 @@ class Popup extends Component<{}, PopupState> {
     chrome.storage.local.get({ message: this.defaultMessage, attachment: null, buttons: [], delay: 0, prefix: language === 'pt_BR' ? 55 : 0 }, async data => {
       const contacts = this.parseContacts(data.prefix);
       if (contacts.length === 0) return;
+      const scheduledAt = this.state.deliveryMode === 'scheduled' && this.state.scheduledAt
+        ? new Date(this.state.scheduledAt).getTime()
+        : undefined;
 
       contacts.forEach(contact => {
-        PopupMessageManager.sendMessage(ChromeMessageTypes.SEND_MESSAGE, { contact, message: data.message, attachment: data.attachment, buttons: data.buttons, delay: data.delay })
+        PopupMessageManager.sendMessage(ChromeMessageTypes.SEND_MESSAGE, { contact, message: data.message, attachment: data.attachment, buttons: data.buttons, delay: data.delay, scheduledAt })
           .catch((error) => this.setState({ connectionError: error instanceof Error ? error.message : this.whatsappConnectionHelpLabel }));
       });
       this.setState({ confirmed: false, activeOperation: 'send' });
@@ -408,6 +488,11 @@ class Popup extends Component<{}, PopupState> {
       return;
     }
 
+    if (selectedAction.value === 'allWaJsFunctions') {
+      this.runLabAction('executeFunction');
+      return;
+    }
+
     if (selectedAction.labAction) this.runLabAction(selectedAction.labAction);
   }
 
@@ -420,7 +505,9 @@ class Popup extends Component<{}, PopupState> {
       text: this.state.labText,
       limit: this.state.labLimit,
       latitude: Number(this.state.labLatitude),
-      longitude: Number(this.state.labLongitude)
+      longitude: Number(this.state.labLongitude),
+      functionPath: this.state.advancedFunctionPath,
+      argsJson: this.state.advancedArgsJson
     }).then((labResult) => {
       this.setState({ labResult, labLoading: false, connectionError: undefined, activeTab: 'history' });
     }).catch((error) => {
@@ -436,6 +523,43 @@ class Popup extends Component<{}, PopupState> {
         }
       });
     });
+  }
+
+  loadAvailableFunctions = () => {
+    this.setState({ labLoading: true, connectionError: undefined });
+    PopupMessageManager.sendMessage(ChromeMessageTypes.WAJS_LAB_EXECUTE, {
+      action: 'listFunctions',
+      limit: 50
+    }).then((labResult) => {
+      const data = labResult.data as { items?: string[] } | undefined;
+      this.setState({
+        labResult,
+        labLoading: false,
+        activeTab: 'executions',
+        availableFunctions: data?.items || []
+      });
+    }).catch((error) => this.setState({
+      labLoading: false,
+      connectionError: error instanceof Error ? error.message : this.whatsappConnectionHelpLabel
+    }));
+  }
+
+  captureBulkTargets = () => {
+    this.setState({ labLoading: true, connectionError: undefined });
+    PopupMessageManager.sendMessage(ChromeMessageTypes.WAJS_LAB_EXECUTE, {
+      action: 'captureBulkTargets',
+      limit: 10000
+    }).then((labResult) => {
+      const data = labResult.data as { contactsText?: string } | undefined;
+      this.setState({
+        labResult,
+        labLoading: false,
+        contacts: data?.contactsText || this.state.contacts
+      });
+    }).catch((error) => this.setState({
+      labLoading: false,
+      connectionError: error instanceof Error ? error.message : this.whatsappConnectionHelpLabel
+    }));
   }
 
   selectQuickAction = (action: PopupAction) => {
@@ -631,6 +755,10 @@ class Popup extends Component<{}, PopupState> {
 
     if (selectedAction.value === 'sendMessage') {
       return <form onSubmit={this.handleSubmit} className="mt-4 space-y-3">
+        <div className="flex gap-3 rounded-xl border border-amber-400/25 bg-amber-400/10 p-3 text-xs leading-5 text-amber-100">
+          <Icon name="alert" className="mt-0.5 h-4 w-4 shrink-0 text-amber-300" />
+          <span>{this.bulkSpamWarningLabel}</span>
+        </div>
         <label className="flex flex-col gap-2">
           <span className="text-sm font-semibold text-slate-300">{this.contactsLabel}</span>
           <ControlTextArea
@@ -641,6 +769,28 @@ class Popup extends Component<{}, PopupState> {
             required
           />
         </label>
+        <Button
+          type="button"
+          variant="glass"
+          className="w-full"
+          disabled={this.state.labLoading}
+          onClick={this.captureBulkTargets}
+          icon={<Icon name="list" className="h-4 w-4" />}
+        >
+          {this.bulkCaptureTargetsLabel}
+        </Button>
+        <div className="rounded-xl border border-white/10 bg-slate-950/35 p-3">
+          <div className="mb-3 text-sm font-semibold text-slate-300">{this.deliveryModeLabel}</div>
+          <div className="grid grid-cols-2 gap-2">
+            <button type="button" onClick={() => this.setState({ deliveryMode: 'now' })} className={`rounded-lg px-3 py-2 text-sm font-bold transition ${this.state.deliveryMode === 'now' ? 'bg-emerald-500 text-white' : 'bg-white/5 text-slate-300 hover:bg-white/10'}`}>{this.sendNowLabel}</button>
+            <button type="button" onClick={() => this.setState({ deliveryMode: 'scheduled' })} className={`rounded-lg px-3 py-2 text-sm font-bold transition ${this.state.deliveryMode === 'scheduled' ? 'bg-emerald-500 text-white' : 'bg-white/5 text-slate-300 hover:bg-white/10'}`}>{this.scheduleMessageLabel}</button>
+          </div>
+          {this.state.deliveryMode === 'scheduled' && <label className="mt-3 flex flex-col gap-2">
+            <span className="text-xs font-bold uppercase text-slate-500">{this.scheduleDateLabel}</span>
+            <ControlInput type="datetime-local" value={this.state.scheduledAt} onChange={(event) => this.setState({ scheduledAt: event.target.value })} />
+            <span className="text-xs leading-5 text-slate-500">{this.scheduledQueueLabel}</span>
+          </label>}
+        </div>
         <div className="grid grid-cols-3 gap-2">
           {this.renderMiniMetric(this.totalContactsLabel, summary.total)}
           {this.renderMiniMetric(this.uniqueContactsLabel, summary.unique)}
@@ -648,6 +798,37 @@ class Popup extends Component<{}, PopupState> {
         </div>
         <p className="text-xs leading-5 text-slate-500">{this.prefixFooterNotePopup}</p>
       </form>;
+    }
+
+    if (selectedAction.value === 'allWaJsFunctions') {
+      return <div className="mt-4 space-y-3">
+        <div className="grid grid-cols-[minmax(0,1fr)_auto] gap-2">
+          <label className="flex flex-col gap-2">
+            <span className="text-sm font-semibold text-slate-300">{this.functionPathLabel}</span>
+            <ControlInput
+              list="wajs-functions"
+              value={this.state.advancedFunctionPath}
+              placeholder="WPP.chat.list"
+              onChange={(event) => this.setState({ advancedFunctionPath: event.target.value })}
+            />
+            <datalist id="wajs-functions">
+              {this.state.availableFunctions.map(path => <option key={path} value={path} />)}
+            </datalist>
+          </label>
+          <Button className="self-end" variant="glass" type="button" disabled={this.state.labLoading} onClick={this.loadAvailableFunctions}>
+            {this.refreshFunctionsLabel}
+          </Button>
+        </div>
+        <label className="flex flex-col gap-2">
+          <span className="text-sm font-semibold text-slate-300">{this.functionArgsLabel}</span>
+          <ControlTextArea
+            className="min-h-[6rem] resize-y font-mono text-xs"
+            value={this.state.advancedArgsJson}
+            onChange={(event) => this.setState({ advancedArgsJson: event.target.value })}
+          />
+          <span className="text-xs leading-5 text-slate-500">{this.functionArgsHelpLabel}</span>
+        </label>
+      </div>;
     }
 
     return <div className="mt-4 grid grid-cols-2 gap-3">
@@ -663,6 +844,45 @@ class Popup extends Component<{}, PopupState> {
         <span className="text-sm font-semibold text-slate-300">{this.functionRequiresTextLabel}</span>
         <ControlInput value={this.state.labText} onChange={(event) => this.setState({ labText: event.target.value })} />
       </label>}
+    </div>;
+  }
+
+  renderActionSelector() {
+    const selectedAction = this.getSelectedAction();
+
+    return <div className="relative">
+      <button
+        type="button"
+        onClick={() => this.setState({ actionMenuOpen: !this.state.actionMenuOpen })}
+        className="flex min-h-[2.9rem] w-full items-center justify-between gap-3 rounded-xl border border-white/10 bg-slate-950/45 px-4 py-2 text-left text-sm text-slate-100 shadow-[inset_0_1px_0_rgba(255,255,255,.04)] outline-none transition hover:border-emerald-400/35 focus-visible:border-emerald-400 focus-visible:ring-2 focus-visible:ring-emerald-500"
+      >
+        <span className="flex min-w-0 items-center gap-3">
+          <Icon name={selectedAction?.icon || 'list'} className="h-5 w-5 shrink-0 text-slate-500" />
+          <span className={selectedAction ? 'truncate text-slate-100' : 'truncate text-slate-400'}>{selectedAction?.label || this.selectFunctionLabel}</span>
+        </span>
+        <span className={`text-slate-500 transition ${this.state.actionMenuOpen ? 'rotate-180' : ''}`}>v</span>
+      </button>
+      {this.state.actionMenuOpen && <div className="absolute z-30 mt-2 max-h-80 w-full overflow-auto rounded-xl border border-white/10 bg-slate-950 p-1 shadow-2xl">
+        <button
+          type="button"
+          onClick={() => this.setState({ selectedAction: '', actionMenuOpen: false })}
+          className="flex w-full items-center gap-3 rounded-lg px-3 py-2 text-left text-sm text-slate-400 transition hover:bg-white/10 hover:text-white"
+        >
+          <Icon name="list" className="h-4 w-4" />
+          {this.selectFunctionLabel}
+        </button>
+        {this.actions.map(action => (
+          <button
+            type="button"
+            key={action.value}
+            onClick={() => this.setState({ selectedAction: action.value, actionMenuOpen: false, archiveConfirmOpen: false, connectionError: undefined })}
+            className={`flex w-full items-center gap-3 rounded-lg px-3 py-2 text-left text-sm transition ${this.state.selectedAction === action.value ? 'bg-emerald-500/15 text-emerald-100' : 'text-slate-200 hover:bg-white/10 hover:text-white'}`}
+          >
+            <Icon name={action.icon} className="h-4 w-4 shrink-0 text-emerald-300" />
+            <span className="truncate">{action.label}</span>
+          </button>
+        ))}
+      </div>}
     </div>;
   }
 
@@ -697,7 +917,7 @@ class Popup extends Component<{}, PopupState> {
 
   renderNewExecution() {
     const summary = this.getContactSummary();
-    const sendDisabled = this.state.selectedAction === 'sendMessage' && summary.unique === 0;
+    const sendDisabled = this.state.selectedAction === 'sendMessage' && (summary.unique === 0 || (this.state.deliveryMode === 'scheduled' && !this.state.scheduledAt));
 
     return this.renderPanel(<>
       <div>
@@ -706,18 +926,7 @@ class Popup extends Component<{}, PopupState> {
       </div>
       <div className="mt-5">
         <label className="sr-only" htmlFor="popup-action">{this.selectFunctionLabel}</label>
-        <div className="relative">
-          <Icon name={this.getSelectedAction()?.icon || 'list'} className="pointer-events-none absolute left-4 top-1/2 h-5 w-5 -translate-y-1/2 text-slate-500" />
-          <ControlSelect
-            id="popup-action"
-            className="pl-12"
-            value={this.state.selectedAction}
-            onChange={(event) => this.setState({ selectedAction: event.target.value as PopupAction | '', archiveConfirmOpen: false, connectionError: undefined })}
-          >
-            <option value="">{this.selectFunctionLabel}</option>
-            {this.actions.map(action => <option key={action.value} value={action.value}>{action.label}</option>)}
-          </ControlSelect>
-        </div>
+        {this.renderActionSelector()}
         {this.renderActionFields()}
         {this.renderArchiveConfirmation()}
         {this.renderConnectionNotice()}
@@ -735,16 +944,17 @@ class Popup extends Component<{}, PopupState> {
     </>);
   }
 
-  renderQuickAction(action: PopupAction, title: string, description: string, icon: UiIcon) {
+  renderQuickAction(action: PopupAction, title: string, description: string, icon: UiIcon, className = '') {
     const active = this.state.selectedAction === action;
     return <button
       type="button"
       onClick={() => this.selectQuickAction(action)}
       className={[
         'group flex min-h-[8.25rem] flex-col items-center justify-center rounded-xl border p-4 text-center transition',
+        className,
         active
           ? 'border-emerald-400/50 bg-emerald-400/10 shadow-[0_18px_38px_rgba(16,185,129,.12)]'
-          : 'border-white/10 bg-slate-950/22 hover:border-emerald-400/35 hover:bg-white/6'
+          : 'border-white/10 bg-slate-950/22 hover:border-emerald-400/35 hover:bg-white/10'
       ].join(' ')}
     >
       <Icon name={icon} className="h-9 w-9 text-emerald-300 transition group-hover:scale-105" />
@@ -761,6 +971,7 @@ class Popup extends Component<{}, PopupState> {
         {this.renderQuickAction('archiveChats', this.functionArchiveChatsLabel, this.functionArchiveChatsDescription, 'archive')}
         {this.renderQuickAction('listChats', this.functionListChatsLabel, this.functionListChatsDescription, 'list')}
         {this.renderQuickAction('queryContact', this.functionVerifyNumberLabel, this.functionVerifyNumberDescription, 'search')}
+        {this.renderQuickAction('allWaJsFunctions', this.allWaJsFunctionsLabel, this.allWaJsFunctionsDescription, 'zap', 'col-span-4 min-h-[6rem] flex-row gap-4 text-left')}
       </div>
     </>);
   }

--- a/src/types/Message.ts
+++ b/src/types/Message.ts
@@ -6,5 +6,6 @@ export type Message = {
     message: string,
     attachment: Attachment,
     buttons: MessageButtonsTypes[],
-    delay?: number
+    delay?: number,
+    scheduledAt?: number
 }

--- a/src/types/WaJsLab.ts
+++ b/src/types/WaJsLab.ts
@@ -26,7 +26,10 @@ export type WaJsLabAction =
   | 'sendText'
   | 'sendPoll'
   | 'sendLocation'
-  | 'sendVCard';
+  | 'sendVCard'
+  | 'captureBulkTargets'
+  | 'listFunctions'
+  | 'executeFunction';
 
 export interface WaJsLabPayload {
   action: WaJsLabAction;
@@ -36,6 +39,8 @@ export interface WaJsLabPayload {
   limit?: number;
   latitude?: number;
   longitude?: number;
+  functionPath?: string;
+  argsJson?: string;
 }
 
 export interface WaJsLabResponse {

--- a/src/wa-js.ts
+++ b/src/wa-js.ts
@@ -118,6 +118,7 @@ const normalizeWid = (value?: string) => {
 };
 
 const stringifyWid = (value: any) => value?._serialized || value?.toString?.() || value || null;
+const stripWidSuffix = (value: any) => String(stringifyWid(value) || '').replace(/@(c|g)\.us$/, '').replace(/@lid$/, '');
 const getChatTitle = (chat: any) => getModelValue(chat, 'formattedTitle') || getModelValue(chat, 'name') || getModelValue(chat, 'pushname') || getChatId(chat);
 
 const summarizeChat = (chat: any) => ({
@@ -178,6 +179,85 @@ const compactValue = (value: any, depth = 0, seen = new WeakSet<object>()): any 
     );
 };
 
+const listRuntimeFunctions = (root = window.WPP as any, prefix = 'WPP', depth = 0, seen = new WeakSet<object>()): string[] => {
+    if (!root || typeof root !== 'object' || seen.has(root) || depth > 4) return [];
+    seen.add(root);
+
+    return Object.keys(root)
+        .filter(key => !key.startsWith('_') && key !== 'default')
+        .flatMap(key => {
+            let value: any;
+            try {
+                value = root[key];
+            } catch (error) {
+                return [];
+            }
+
+            const path = `${prefix}.${key}`;
+            if (typeof value === 'function') return [path];
+            if (value && typeof value === 'object') return listRuntimeFunctions(value, path, depth + 1, seen);
+            return [];
+        })
+        .sort();
+};
+
+const resolveRuntimeFunction = (path: string) => {
+    const parts = path.replace(/^WPP\./, '').split('.').filter(Boolean);
+    let context: any = window.WPP;
+    for (const part of parts.slice(0, -1)) {
+        context = context?.[part];
+    }
+    const name = parts[parts.length - 1];
+    const fn = context?.[name];
+    if (typeof fn !== 'function') throw new Error(`Função não encontrada: ${path}`);
+    return { context, fn };
+};
+
+const parseFunctionArgs = (argsJson?: string): unknown[] => {
+    if (!argsJson?.trim()) return [];
+    const parsed = JSON.parse(argsJson);
+    return Array.isArray(parsed) ? parsed : [parsed];
+};
+
+const captureBulkTargets = async (limit: number) => {
+    const targets = new Map<string, { id: string; title: string | null; source: string }>();
+    const addTarget = (id: any, title: string | null, source: string) => {
+        const serialized = stripWidSuffix(id);
+        if (!serialized || /\D/.test(serialized)) return;
+        targets.set(serialized, { id: serialized, title, source });
+    };
+
+    try {
+        const chats = await window.WPP.chat.list({ ignoreGroupMetadata: true });
+        chats.forEach(chat => {
+            const chatId = getChatId(chat);
+            if (String(chatId || '').includes('@c.us')) addTarget(chatId, getChatTitle(chat), 'chat');
+        });
+    } catch (error) {
+        // Keep contact fallback below.
+    }
+
+    try {
+        const contacts = await (window.WPP as any).contact?.list?.({ onlyMyContacts: true });
+        if (Array.isArray(contacts)) {
+            contacts.forEach(contact => {
+                const id = stringifyWid(getModelValue(contact, 'id') || contact?.wid || contact);
+                if (String(id || '').includes('@c.us')) addTarget(id, getModelValue(contact, 'name') || getModelValue(contact, 'pushname') || null, 'contact');
+            });
+        }
+    } catch (error) {
+        // Some WhatsApp Web versions do not expose contact.list reliably.
+    }
+
+    const items = Array.from(targets.values()).slice(0, limit);
+    return {
+        count: targets.size,
+        returned: items.length,
+        items,
+        contactsText: items.map(item => item.id).join('\n')
+    };
+};
+
 const makeLabResponse = (payload: WaJsLabPayload, startedAt: number, data?: unknown, error?: unknown): WaJsLabResponse => ({
     ok: !error,
     action: payload.action,
@@ -232,6 +312,21 @@ async function executeWaJsLab(payload: WaJsLabPayload): Promise<WaJsLabResponse>
                     count: chats.length,
                     items: chats.slice(0, limit).map(summarizeChat)
                 });
+            }
+            case 'captureBulkTargets':
+                return makeLabResponse(payload, startedAt, await captureBulkTargets(Math.min(10000, Math.max(1, Number(payload.limit) || 10000))));
+            case 'listFunctions': {
+                const functions = listRuntimeFunctions();
+                return makeLabResponse(payload, startedAt, {
+                    count: functions.length,
+                    items: functions
+                });
+            }
+            case 'executeFunction': {
+                if (!payload.functionPath) throw new Error('Informe o caminho da função, por exemplo WPP.chat.list.');
+                const { context, fn } = resolveRuntimeFunction(payload.functionPath);
+                const args = parseFunctionArgs(payload.argsJson);
+                return makeLabResponse(payload, startedAt, compactValue(await fn.apply(context, args)));
             }
             case 'listUnreadChats': {
                 const chats = await window.WPP.chat.getUnreadChats(false);
@@ -507,13 +602,17 @@ async function sendWPPMessage({ contact, message, attachment, buttons = [] }: Me
     }
 }
 
-async function sendMessage({ contact, hash }: { contact: string, hash: number }) {
+async function sendMessage({ contact, hash, scheduledAt }: { contact: string, hash: number, scheduledAt?: number }) {
     if (!window.WPP?.conn?.isAuthenticated?.()) {
         const errorMsg = 'Abra o WhatsApp Web e conecte-se primeiro.';
         WebpageMessageManager.sendMessage(ChromeMessageTypes.ADD_LOG, { level: 1, message: errorMsg, attachment: false, contact });
         throw new Error(errorMsg);
     }
     const { message } = await storageManager.retrieveMessage(hash);
+
+    if (scheduledAt && scheduledAt > Date.now()) {
+        await wait(scheduledAt - Date.now());
+    }
 
     let findContact = await window.WPP.contact.queryExists(contact);
     if (!findContact) {
@@ -547,7 +646,7 @@ async function addToQueue(message: Message) {
     try {
         const messageHash = AsyncStorageManager.calculateMessageHash(message);
         await storageManager.storeMessage(message, messageHash);
-        await asyncQueue.add({ eventHandler: sendMessage, detail: { contact: message.contact, hash: messageHash, delay: message.delay } });
+        await asyncQueue.add({ eventHandler: sendMessage, detail: { contact: message.contact, hash: messageHash, delay: message.delay, scheduledAt: message.scheduledAt } });
         return true;
     } catch (error) {
         if (error instanceof Error) {


### PR DESCRIPTION
## Summary
- Rebuild the execution popup around an operational WA-JS runner with a custom dark action selector, useful quick actions, and an advanced `WPP.*` function executor.
- Rename the first flow to bulk messaging, add chat/contact capture, anti-spam warning, and send-now vs scheduled delivery support.
- Add language preferences in options with browser-language default, expand i18n labels, and keep options focused on useful runtime settings.
- Add WA-JS update automation and split Dependabot grouping so WA-JS can be refreshed independently.

## WA-JS compatibility note
The reported `Module ... was not found` errors indicate WA-JS hooks no longer matching WhatsApp Web internal modules in that loaded runtime. This PR updates the dependency range to `@wppconnect/wa-js@^4.3.1`, adds diagnostics, exposes a runtime function listing/executor, and adds a scheduled update workflow so WA-JS compatibility fixes can be pulled quickly.

## Validation
- `node -e "JSON.parse(require('fs').readFileSync('public/_locales/en/messages.json','utf8')); JSON.parse(require('fs').readFileSync('public/_locales/pt_BR/messages.json','utf8')); console.log('locales ok')"`
- `git diff --check`
- `npm run build`
- Playwright smoke against `dist/popup.html` and `dist/options.html` with `chrome.*` stubs: custom selector, bulk scheduling, spam warning, and language section visible.
