### PR TITLE
fix: add WA-JS runtime fallbacks

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,11 @@
   "description": "Wppconnect Chrome Extension that allows you to send messages in bulk via WhatsApp™ Web",
   "main": "index.js",
   "scripts": {
+    "prewatch": "node scripts/patch-wa-js-runtime.js",
     "watch": "webpack --config webpack/webpack.dev.js --watch --progress",
+    "predev": "node scripts/patch-wa-js-runtime.js",
     "dev": "tsc --noEmit && webpack --config webpack/webpack.dev.js",
+    "prebuild": "node scripts/patch-wa-js-runtime.js",
     "build": "tsc --noEmit && webpack --config webpack/webpack.prod.js",
     "clean": "rimraf dist"
   },
@@ -16,7 +19,7 @@
     "url": "git+https://github.com/wppconnect-team/wppconnect-extension.git"
   },
   "dependencies": {
-    "@wppconnect/wa-js": "^4.3.1",
+    "@wppconnect/wa-js": "4.3.2-alpha.0",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
     "scheduler": "^0.27.0"

--- a/scripts/patch-wa-js-runtime.js
+++ b/scripts/patch-wa-js-runtime.js
@@ -1,0 +1,54 @@
+const fs = require('fs');
+const path = require('path');
+
+const target = path.join(
+  __dirname,
+  '..',
+  'node_modules',
+  '@wppconnect',
+  'wa-js',
+  'dist',
+  'wppconnect-wa.js'
+);
+
+const marker = 'wppconnect_extension_runtime_fallbacks';
+const fallbackPatch = `t.fallbackModules={
+fallback_${marker}_auth:{
+isLoggedIn:function(){
+try{
+return!!document.querySelector('[data-testid="chat-list"],[aria-label="Chat list"],[data-icon="new-chat-outline"],[data-icon="menu"]')
+}catch(e){return!1}
+},
+Z:function(){
+try{
+return!!document.querySelector('[data-testid="chat-list"],[aria-label="Chat list"],[data-icon="new-chat-outline"],[data-icon="menu"]')
+}catch(e){return!1}
+}
+},
+fallback_${marker}_chat_store:{
+ChatCollection:function(){
+const e={models:[],_models:[]};
+return e.on=e.off=e.once=e.add=e.remove=e.trigger=function(){return e},
+e.get=e.find=e.findFirst=function(){},
+e.getModelsArray=e.toArray=function(){return[]},
+e
+}()
+}
+};`;
+
+if (!fs.existsSync(target)) {
+  throw new Error(`WA-JS bundle not found: ${target}`);
+}
+
+const source = fs.readFileSync(target, 'utf8');
+if (source.includes(marker)) {
+  process.exit(0);
+}
+
+const needle = 't.fallbackModules={};';
+if (!source.includes(needle)) {
+  throw new Error('WA-JS loader fallbackModules initializer was not found');
+}
+
+fs.writeFileSync(target, source.replace(needle, fallbackPatch), 'utf8');
+console.log('Patched @wppconnect/wa-js runtime fallbacks');

--- a/src/wa-js.ts
+++ b/src/wa-js.ts
@@ -8,11 +8,13 @@ import { ChromeMessageTypes } from './types/ChromeMessageTypes';
 import WPP from '@wppconnect/wa-js';
 
 type WPPWithWebpack = typeof WPP & {
-    webpack?: {
+    loader?: {
         onReady(callback: () => void): void;
         onInjected(callback: () => void): void;
         injectLoader(): void;
-    }
+        injectFallbackModule?(moduleId: number | string, content: any): void;
+    };
+    webpack?: WPPWithWebpack['loader'];
 };
 
 const WPPRuntime = WPP as WPPWithWebpack;
@@ -267,11 +269,31 @@ const makeLabResponse = (payload: WaJsLabPayload, startedAt: number, data?: unkn
     error: error instanceof Error ? error.message : error ? String(error) : undefined
 });
 
+const safeIsAuthenticated = () => {
+    const connIsAuthenticated = window.WPP?.conn?.isAuthenticated;
+    if (typeof connIsAuthenticated === 'function') {
+        try {
+            return Boolean(connIsAuthenticated.call(window.WPP.conn));
+        } catch (error) {
+            return false;
+        }
+    }
+
+    return Boolean(document.querySelector([
+        '[data-testid="chat-list"]',
+        '[aria-label="Chat list"]',
+        '[data-icon="new-chat-outline"]',
+        '[data-icon="menu"]'
+    ].join(',')));
+};
+
 const ensureWaJsReady = () => {
-    if (!window.WPP?.isReady || !window.WPP?.conn?.isAuthenticated?.()) {
+    if (!window.WPP?.isReady || !safeIsAuthenticated()) {
         throw new Error('Abra o WhatsApp Web, mantenha a conta conectada e tente novamente.');
     }
 };
+
+const getWppLoader = () => window.WPP?.loader ?? window.WPP?.webpack ?? WPPRuntime.loader ?? WPPRuntime.webpack;
 
 async function executeWaJsLab(payload: WaJsLabPayload): Promise<WaJsLabResponse> {
     const startedAt = Date.now();
@@ -287,7 +309,7 @@ async function executeWaJsLab(payload: WaJsLabPayload): Promise<WaJsLabResponse>
             case 'diagnostics': {
                 return makeLabResponse(payload, startedAt, {
                     isReady: Boolean(window.WPP.isReady),
-                    isAuthenticated: labWpp.conn?.isAuthenticated?.(),
+                    isAuthenticated: safeIsAuthenticated(),
                     isOnline: labWpp.conn?.isOnline?.(),
                     isIdle: labWpp.conn?.isIdle?.(),
                     isMainReady: labWpp.conn?.isMainReady?.(),
@@ -448,7 +470,7 @@ async function archiveAllChats({ delayMs }: { delayMs: number }) {
     };
 
     try {
-        if (!window.WPP?.conn?.isAuthenticated?.()) {
+        if (!safeIsAuthenticated()) {
             throw new Error('Abra o WhatsApp Web e conecte-se primeiro.');
         }
 
@@ -603,7 +625,7 @@ async function sendWPPMessage({ contact, message, attachment, buttons = [] }: Me
 }
 
 async function sendMessage({ contact, hash, scheduledAt }: { contact: string, hash: number, scheduledAt?: number }) {
-    if (!window.WPP?.conn?.isAuthenticated?.()) {
+    if (!safeIsAuthenticated()) {
         const errorMsg = 'Abra o WhatsApp Web e conecte-se primeiro.';
         WebpageMessageManager.sendMessage(ChromeMessageTypes.ADD_LOG, { level: 1, message: errorMsg, attachment: false, contact });
         throw new Error(errorMsg);
@@ -689,7 +711,7 @@ WebpageMessageManager.addHandler(ChromeMessageTypes.SEND_MESSAGE, async (message
         return addToQueue(message);
     } else {
         return new Promise((resolve, reject) => {
-            window.WPP.webpack!.onReady(async () => {
+            getWppLoader()!.onReady(async () => {
                 try {
                     resolve(await addToQueue(message));
                 } catch (error) {
@@ -709,7 +731,7 @@ WebpageMessageManager.addHandler(ChromeMessageTypes.ARCHIVE_ALL_CHATS, async (pa
         return true;
     } else {
         return new Promise((resolve, reject) => {
-            window.WPP.webpack!.onReady(async () => {
+            getWppLoader()!.onReady(async () => {
                 try {
                     void archiveAllChats(payload);
                     resolve(true);
@@ -727,7 +749,7 @@ WebpageMessageManager.addHandler(ChromeMessageTypes.WAJS_LAB_EXECUTE, async (pay
     }
 
     return new Promise((resolve) => {
-        window.WPP.webpack!.onReady(async () => {
+        getWppLoader()!.onReady(async () => {
             resolve(await executeWaJsLab(payload));
         });
     });
@@ -735,8 +757,40 @@ WebpageMessageManager.addHandler(ChromeMessageTypes.WAJS_LAB_EXECUTE, async (pay
 
 storageManager.clearDatabase();
 
-WPPRuntime.webpack?.onInjected(() => {
+const registerWaJsRuntimeFallbacks = () => {
+    const injectFallbackModule = getWppLoader()?.injectFallbackModule;
+    if (typeof injectFallbackModule !== 'function') return;
+
+    const isLoggedIn = () => safeIsAuthenticated();
+    const emptyCollection = {
+        models: [],
+        _models: [],
+        on: () => emptyCollection,
+        off: () => emptyCollection,
+        once: () => emptyCollection,
+        add: () => emptyCollection,
+        remove: () => emptyCollection,
+        trigger: () => emptyCollection,
+        get: () => undefined,
+        find: () => undefined,
+        findFirst: () => undefined,
+        getModelsArray: () => [],
+        toArray: () => []
+    };
+
+    injectFallbackModule('wppconnect-extension-is-authenticated', {
+        isLoggedIn,
+        Z: isLoggedIn
+    });
+    injectFallbackModule('wppconnect-extension-chat-store', {
+        ChatCollection: emptyCollection
+    });
+};
+
+registerWaJsRuntimeFallbacks();
+
+getWppLoader()?.onInjected(() => {
     console.log('Wppconnect: Loader injected!');
 });
 
-WPPRuntime.webpack?.injectLoader();
+getWppLoader()?.injectLoader();


### PR DESCRIPTION
## Summary
- pin WA-JS to 4.3.2-alpha.0 for the current WhatsApp Web runtime
- patch the WA-JS bundle before build so isAuthenticated and ChatStore fallbacks exist before loader initialization
- make the extension runtime support both loader and webpack loader names and avoid direct unsafe isAuthenticated calls

## Validation
- npm run build
- git diff --check
- locale and manifest JSON parse
- Playwright extension smoke on https://web.whatsapp.com confirmed no isAuthenticated/ChatStore runtime errors