### PR TITLE
fix: apply saved extension language

### DIFF
--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -774,12 +774,8 @@
         "description": "Language settings section title"
     },
     "languageSettingsHelp": {
-        "message": "The default follows the browser language. Change it here for extension screens that support manual language preference.",
+        "message": "The extension uses the browser language as the initial value. This choice controls extension screens from now on.",
         "description": "Language settings help"
-    },
-    "languageAutoLabel": {
-        "message": "Automatic",
-        "description": "Automatic language option"
     },
     "languageEnglishLabel": {
         "message": "English",

--- a/public/_locales/pt_BR/messages.json
+++ b/public/_locales/pt_BR/messages.json
@@ -774,12 +774,8 @@
         "description": "Título da seção de idioma"
     },
     "languageSettingsHelp": {
-        "message": "O padrão segue o idioma do navegador. Altere aqui para telas da extensão que respeitam preferência manual de idioma.",
+        "message": "A extensão usa o idioma do navegador como valor inicial. Depois disso, a escolha aqui controla as telas da extensão.",
         "description": "Ajuda da configuração de idioma"
-    },
-    "languageAutoLabel": {
-        "message": "Automático",
-        "description": "Opção de idioma automático"
     },
     "languageEnglishLabel": {
         "message": "Inglês",

--- a/src/components/molecules/SelectCountryCode.tsx
+++ b/src/components/molecules/SelectCountryCode.tsx
@@ -1,19 +1,19 @@
 import React, { ChangeEvent, Component, createRef } from 'react';
 import { ControlInput } from '../atoms/ControlFactory';
+import { getActiveLanguage } from '../../utils/i18n';
 
 interface CountryCode {
     value: number;
     label: string;
 }
 
-const language = chrome.i18n.getUILanguage().substring(0, 2);
-let countryCodes: CountryCode[] = [];
-try {
-    countryCodes = require(`../../countryCodes.${language}.json`);
-} catch (e) {
-    console.log(e);
-    countryCodes = require('../../countryCodes.en.json');
-}
+const countryCodesByLanguage: Record<string, CountryCode[]> = {
+    en: require('../../countryCodes.en.json'),
+    pt_BR: require('../../countryCodes.pt.json')
+};
+
+const countryCodes = () => countryCodesByLanguage[getActiveLanguage()] || countryCodesByLanguage.en;
+const defaultPrefix = () => getActiveLanguage() === 'pt_BR' ? 55 : 0;
 
 export default class SelectCountryCode extends Component<{ options?: CountryCode[] }, {
     isOpen: boolean,
@@ -27,12 +27,12 @@ export default class SelectCountryCode extends Component<{ options?: CountryCode
         this.defaultLabelSelectCountryCode = chrome.i18n.getMessage('defaultLabelSelectCountryCode');
         this.searchPlaceholder = chrome.i18n.getMessage('countryCodeSearchPlaceholder') || 'Search';
         this.emptyLabel = chrome.i18n.getMessage('countryCodeEmptyLabel') || 'No prefix found';
-        const defaultOptions = [{ value: 0, label: this.defaultLabelSelectCountryCode }, ...countryCodes];
+        const defaultOptions = [{ value: 0, label: this.defaultLabelSelectCountryCode }, ...countryCodes()];
         const { options = defaultOptions } = props;
         this.state = {
             isOpen: false,
             searchValue: '',
-            selectedValue: chrome.i18n.getUILanguage() === 'pt_BR' ? options.find(option => option.value === 55) : options.find(option => option.value === 0),
+            selectedValue: options.find(option => option.value === defaultPrefix()),
             options,
             filteredOptions: options,
         };
@@ -72,7 +72,7 @@ export default class SelectCountryCode extends Component<{ options?: CountryCode
     componentDidMount() {
         document.addEventListener('mousedown', this.handleClickOutside);
         chrome.storage.local.get(
-            { prefix: chrome.i18n.getUILanguage() === 'pt_BR' ? 55 : 0 },
+            { prefix: defaultPrefix() },
             data => {
                 this.setState({ selectedValue: this.state.options.find(option => option.value === data.prefix) });
             });

--- a/src/components/organisms/LanguageForm.tsx
+++ b/src/components/organisms/LanguageForm.tsx
@@ -1,32 +1,33 @@
 import React, { ChangeEvent, Component } from 'react';
 import Box from '../molecules/Box';
+import { AppLanguage, detectBrowserLanguage, getActiveLanguage, normalizeLanguage, setLanguagePreference } from '../../utils/i18n';
 
-type Language = 'auto' | 'en' | 'pt_BR';
-
-const browserLanguage = (): Language => chrome.i18n.getUILanguage() === 'pt_BR' ? 'pt_BR' : 'en';
-
-export default class LanguageForm extends Component<{}, { language: Language }>{
+export default class LanguageForm extends Component<{}, { language: AppLanguage }>{
     constructor(props: {}) {
         super(props);
         this.state = {
-            language: 'auto'
+            language: getActiveLanguage()
         };
     }
 
     title = chrome.i18n.getMessage('languageSettingsTitle') || 'Language';
-    help = chrome.i18n.getMessage('languageSettingsHelp') || 'The default follows the browser language. Change it here for extension screens that support manual language preference.';
-    autoLabel = `${chrome.i18n.getMessage('languageAutoLabel') || 'Automatic'} (${browserLanguage()})`;
+    help = chrome.i18n.getMessage('languageSettingsHelp') || 'The extension uses the browser language as the initial value. This choice controls extension screens from now on.';
     englishLabel = chrome.i18n.getMessage('languageEnglishLabel') || 'English';
     portugueseLabel = chrome.i18n.getMessage('languagePortugueseLabel') || 'Portuguese (Brazil)';
 
     componentDidMount() {
-        chrome.storage.local.get({ language: 'auto' }, data => this.setState({ language: data.language || 'auto' }));
+        const browserLanguage = detectBrowserLanguage();
+        chrome.storage.local.get({ language: browserLanguage }, data => {
+            const language = data.language === 'auto' ? browserLanguage : normalizeLanguage(data.language);
+            if (data.language !== language) void setLanguagePreference(language);
+            this.setState({ language });
+        });
     }
 
     handleLanguageChange = (event: ChangeEvent<HTMLSelectElement>) => {
-        const language = event.target.value as Language;
+        const language = normalizeLanguage(event.target.value);
         this.setState({ language });
-        chrome.storage.local.set({ language, resolvedLanguage: language === 'auto' ? browserLanguage() : language });
+        void setLanguagePreference(language).then(() => window.location.reload());
     }
 
     render() {
@@ -38,7 +39,6 @@ export default class LanguageForm extends Component<{}, { language: Language }>{
                     onChange={this.handleLanguageChange}
                     className="min-h-[2.75rem] rounded-lg border border-white/10 bg-slate-950/35 px-3 py-2 text-sm text-slate-100 outline-none transition focus:border-emerald-400 focus:ring-2 focus:ring-emerald-500"
                 >
-                    <option value="auto">{this.autoLabel}</option>
                     <option value="en">{this.englishLabel}</option>
                     <option value="pt_BR">{this.portugueseLabel}</option>
                 </select>

--- a/src/options.tsx
+++ b/src/options.tsx
@@ -6,6 +6,7 @@ import LanguageForm from './components/organisms/LanguageForm';
 import LogTable from './components/organisms/LogTable';
 import MessageButtonsForm from './components/organisms/MessageButtonsForm';
 import MessageForm from './components/organisms/MessageForm';
+import { initI18n } from './utils/i18n';
 
 class Options extends Component<{}, {}>{
   title = chrome.i18n.getMessage('optionsPageTitle') || 'Wppconnect settings';
@@ -37,5 +38,7 @@ class Options extends Component<{}, {}>{
   }
 }
 
-createRoot(document.getElementById('root')!)
-  .render(<Options />);
+void initI18n().then(() => {
+  createRoot(document.getElementById('root')!)
+    .render(<Options />);
+});

--- a/src/popup.tsx
+++ b/src/popup.tsx
@@ -11,6 +11,7 @@ import type { ScheduledExecution } from './types/ScheduledExecution';
 import { WaJsLabAction, WaJsLabMediaType, WaJsLabPayload, WaJsLabResponse } from './types/WaJsLab';
 import AsyncChromeMessageManager from './utils/AsyncChromeMessageManager';
 import { ChromeMessageTypes } from './types/ChromeMessageTypes';
+import { getActiveLanguage, initI18n } from './utils/i18n';
 
 const PopupMessageManager = new AsyncChromeMessageManager('popup');
 
@@ -501,7 +502,7 @@ class Popup extends Component<{}, PopupState> {
   }
 
   startSendMessages = () => {
-    const language = chrome.i18n.getUILanguage();
+    const language = getActiveLanguage();
     chrome.storage.local.get({ message: this.defaultMessage, attachment: null, buttons: [], delay: 0, prefix: language === 'pt_BR' ? 55 : 0 }, async data => {
       const contacts = this.parseContacts(data.prefix);
       if (contacts.length === 0) return;
@@ -611,7 +612,7 @@ class Popup extends Component<{}, PopupState> {
     if (!selectedAction || !this.state.scheduledAt) return;
 
     if (selectedAction.value === 'sendMessage') {
-      const language = chrome.i18n.getUILanguage();
+      const language = getActiveLanguage();
       chrome.storage.local.get({ message: this.defaultMessage, attachment: null, buttons: [], delay: 0, prefix: language === 'pt_BR' ? 55 : 0 }, data => {
         const contacts = this.parseContacts(data.prefix);
         if (contacts.length === 0) return;
@@ -1446,5 +1447,7 @@ class Popup extends Component<{}, PopupState> {
   }
 }
 
-createRoot(document.getElementById('root')!)
-  .render(<Popup />);
+void initI18n().then(() => {
+  createRoot(document.getElementById('root')!)
+    .render(<Popup />);
+});

--- a/src/utils/i18n.ts
+++ b/src/utils/i18n.ts
@@ -1,0 +1,98 @@
+export type AppLanguage = 'en' | 'pt_BR';
+
+type LocaleMessage = {
+  message?: string;
+  placeholders?: Record<string, { content?: string }>;
+};
+
+type LocaleMessages = Record<string, LocaleMessage>;
+
+let activeMessages: LocaleMessages = {};
+const nativeGetMessage = chrome.i18n.getMessage.bind(chrome.i18n);
+const nativeGetUILanguage = chrome.i18n.getUILanguage.bind(chrome.i18n);
+let activeLanguage: AppLanguage = detectBrowserLanguage();
+
+export function detectBrowserLanguage(): AppLanguage {
+  const language = nativeGetUILanguage();
+  return language === 'pt_BR' || language.toLowerCase().startsWith('pt') ? 'pt_BR' : 'en';
+}
+
+export function normalizeLanguage(language?: string): AppLanguage {
+  return language === 'pt_BR' ? 'pt_BR' : 'en';
+}
+
+export function getActiveLanguage(): AppLanguage {
+  return activeLanguage;
+}
+
+function storageGet<T extends Record<string, unknown>>(defaults: T): Promise<T> {
+  return new Promise(resolve => chrome.storage.local.get(defaults, data => resolve(data as T)));
+}
+
+function storageSet(values: Record<string, unknown>): Promise<void> {
+  return new Promise(resolve => chrome.storage.local.set(values, resolve));
+}
+
+function normalizeSubstitutions(substitutions?: string | string[]) {
+  if (!substitutions) return [];
+  return Array.isArray(substitutions) ? substitutions : [substitutions];
+}
+
+function formatMessage(entry: LocaleMessage | undefined, substitutions?: string | string[]) {
+  if (!entry?.message) return '';
+
+  const values = normalizeSubstitutions(substitutions);
+  let message = entry.message;
+
+  Object.entries(entry.placeholders || {}).forEach(([name, placeholder]) => {
+    const match = placeholder.content?.match(/^\$(\d+)$/);
+    if (!match) return;
+    const value = values[Number(match[1]) - 1] || '';
+    message = message.replace(new RegExp(`\\$${name}\\$`, 'gi'), value);
+  });
+
+  values.forEach((value, index) => {
+    message = message.replace(new RegExp(`\\$${index + 1}`, 'g'), value);
+  });
+
+  return message;
+}
+
+export function getMessage(key: string, substitutions?: string | string[]) {
+  return formatMessage(activeMessages[key], substitutions) || nativeGetMessage(key, substitutions as any);
+}
+
+function patchChromeI18n() {
+  try {
+    (chrome.i18n as any).getMessage = getMessage;
+    (chrome.i18n as any).getUILanguage = () => activeLanguage;
+  } catch (error) {
+    // Chrome APIs are not expected to be readonly, but keep native behavior if a test shim is.
+  }
+}
+
+export async function setLanguagePreference(language: AppLanguage) {
+  await storageSet({ language, resolvedLanguage: language });
+}
+
+export async function initI18n() {
+  const browserLanguage = detectBrowserLanguage();
+  const data = await storageGet<{ language: string; resolvedLanguage: string }>({ language: browserLanguage, resolvedLanguage: browserLanguage });
+  const storedLanguage = data.language === 'auto' ? browserLanguage : normalizeLanguage(String(data.language || browserLanguage));
+
+  activeLanguage = storedLanguage;
+
+  if (data.language !== storedLanguage || data.resolvedLanguage !== storedLanguage) {
+    await setLanguagePreference(storedLanguage);
+  }
+
+  try {
+    const response = await fetch(chrome.runtime.getURL(`_locales/${storedLanguage}/messages.json`));
+    activeMessages = await response.json();
+  } catch (error) {
+    activeMessages = {};
+  }
+
+  patchChromeI18n();
+  return activeLanguage;
+}


### PR DESCRIPTION
## Summary
- load the stored extension language before rendering popup/options screens
- remove the visible Automatic language option and migrate old `auto` values to the browser language silently
- make country-code defaults follow the active extension language instead of the raw browser locale

## Validation
- npm run build
- node -e "JSON.parse(require('fs').readFileSync('public/_locales/en/messages.json','utf8')); JSON.parse(require('fs').readFileSync('public/_locales/pt_BR/messages.json','utf8')); console.log('locale json ok')"
- local mocked smoke: browser `pt_BR` + stored `en` renders Options in English with only English/Portuguese choices