### PR TITLE
fix: keep Update WA-JS build compatible

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "speed-measure-webpack-plugin": "^1.5.0",
     "tailwindcss": "^4.3.1",
     "ts-loader": "^9.4.4",
-    "typescript": "^7.0.2",
+    "typescript": "~6.0.3",
     "webpack-cli": "^7.0.3",
     "webpack-merge": "^6.0.1"
   }

--- a/src/content_script.ts
+++ b/src/content_script.ts
@@ -10,13 +10,15 @@ const SCHEDULED_EXECUTIONS_KEY = 'scheduledExecutions';
 const SCHEDULE_RESPONSE_TIMEOUT_MS = 60000;
 const scheduledTimers: Record<string, number> = {};
 
-type MessageData<K extends keyof ChromeMessageContentTypes> = {
+type MessageType = Extract<keyof ChromeMessageContentTypes, string>;
+
+type MessageData<K extends MessageType> = {
   source: 'Wppconnect';
   type: K;
   payload: ChromeMessageContentTypes[K]['payload'];
 };
 
-type MessageDataResponse<K extends keyof ChromeMessageContentTypes> = {
+type MessageDataResponse<K extends MessageType> = {
   source: 'Wppconnect';
   type: `${K}_RESPONSE`;
   payload: ChromeMessageContentTypes[K]['response'];
@@ -107,7 +109,7 @@ async function updateScheduledExecution(id: string, patch: Partial<ScheduledExec
   return updated;
 }
 
-function sendWebpageMessage<K extends keyof ChromeMessageContentTypes>(
+function sendWebpageMessage<K extends MessageType>(
   type: K,
   payload: ChromeMessageContentTypes[K]['payload'],
   timeoutMs = SCHEDULE_RESPONSE_TIMEOUT_MS

--- a/src/utils/AsyncChromeMessageManager.ts
+++ b/src/utils/AsyncChromeMessageManager.ts
@@ -1,18 +1,20 @@
 import ChromeMessageContentTypes from "types/ChromeMessageContentTypes";
 
-type MessageData<K extends keyof ChromeMessageContentTypes> = {
+type MessageType = Extract<keyof ChromeMessageContentTypes, string>;
+
+type MessageData<K extends MessageType> = {
   source: 'Wppconnect';
   type: K;
   payload: ChromeMessageContentTypes[K]["payload"];
 };
 
-type MessageDataResponse<K extends keyof ChromeMessageContentTypes> = {
+type MessageDataResponse<K extends MessageType> = {
   source: 'Wppconnect';
   type: `${K}_RESPONSE`;
   payload: ChromeMessageContentTypes[K]["response"];
 };
 
-type MessageHandler<K extends keyof ChromeMessageContentTypes> = (
+type MessageHandler<K extends MessageType> = (
   payload: ChromeMessageContentTypes[K]["payload"]
 ) => ChromeMessageContentTypes[K]["response"] | Promise<ChromeMessageContentTypes[K]["response"]>;
 
@@ -51,7 +53,7 @@ export default class AsyncChromeMessageManager {
     });
   }
 
-  public addHandler<K extends keyof ChromeMessageContentTypes>(type: K, handler: MessageHandler<K>) {
+  public addHandler<K extends MessageType>(type: K, handler: MessageHandler<K>) {
     try {
       if (this.source !== "webpage") {
         this.addExtensionMessageHandler(type, handler);
@@ -64,7 +66,7 @@ export default class AsyncChromeMessageManager {
     }
   }
 
-  private addWebpageMessageHandler<K extends keyof ChromeMessageContentTypes>(type: K, handler: MessageHandler<K>) {
+  private addWebpageMessageHandler<K extends MessageType>(type: K, handler: MessageHandler<K>) {
     window.addEventListener("message", async (event) => {
       if (event.source === window && event.origin === window.location.origin && event.data.type === type && event.data.source === 'Wppconnect') {
         try {
@@ -77,7 +79,7 @@ export default class AsyncChromeMessageManager {
     });
   }
 
-  private addExtensionMessageHandler<K extends keyof ChromeMessageContentTypes>(type: K, handler: MessageHandler<K>) {
+  private addExtensionMessageHandler<K extends MessageType>(type: K, handler: MessageHandler<K>) {
     chrome.runtime.onMessage.addListener(async (message) => {
       if (message.source === 'Wppconnect' && message.type === type) {
         try {
@@ -94,7 +96,7 @@ export default class AsyncChromeMessageManager {
     });
   }
 
-  public async sendMessage<K extends keyof ChromeMessageContentTypes>(
+  public async sendMessage<K extends MessageType>(
     type: K,
     payload: ChromeMessageContentTypes[K]["payload"]
   ): Promise<ChromeMessageContentTypes[K]["response"]> {
@@ -142,7 +144,7 @@ export default class AsyncChromeMessageManager {
     });
   }
 
-  private sendWebpageMessage<K extends keyof ChromeMessageContentTypes>(
+  private sendWebpageMessage<K extends MessageType>(
     message: MessageData<K>, listener: (response: MessageDataResponse<K>) => void
   ) {
     window.postMessage(message, window.location.origin);
@@ -156,7 +158,7 @@ export default class AsyncChromeMessageManager {
     return () => window.removeEventListener("message", responseListener);
   }
 
-  private sendExtensionMessage<K extends keyof ChromeMessageContentTypes>(
+  private sendExtensionMessage<K extends MessageType>(
     message: MessageData<K>,
     listener: (response: MessageDataResponse<K>) => void,
     reject: (error: Error) => void

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,10 +1,16 @@
 {
     "extends": "@tsconfig/recommended/tsconfig.json",
     "compilerOptions": {
-        "baseUrl": "./src",
         "jsx": "react-jsx",
-        "moduleResolution": "Node",
         "ignoreDeprecations": "6.0",
+        "paths": {
+            "*": [
+                "./src/*"
+            ],
+            "@wppconnect/wa-js/dist/*": [
+                "./node_modules/@wppconnect/wa-js/dist/*"
+            ]
+        },
         "types": [
             "chrome",
             "node"


### PR DESCRIPTION
## Summary
- Pins TypeScript to the supported 6.0.x line because the latest TypeScript 7 breaks the current ts-loader webpack build.
- Replaces removed TS 7 tsconfig options with `paths` mappings for source imports and WA-JS deep type imports.
- Narrows Chrome message generic keys to strings to avoid TS 7 symbol-key diagnostics.

## Validation
- `npm install --package-lock=false`
- `node scripts/download-wa-js-release.js`
- locale JSON parse check for `en` and `pt_BR`
- `npm run build`

Root cause from failed run 29014662242: `npm install` pulled TypeScript 7 from `^7.0.2`, then `tsc` failed on removed `baseUrl` and `moduleResolution=node10`; after those were fixed, current `ts-loader@9.6.2` still failed against TypeScript 7 during webpack.