### PR TITLE
fix: prevent unsafe TypeScript dependabot merge

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,10 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    ignore:
+      - dependency-name: "typescript"
+        update-types:
+          - "version-update:semver-major"
     allow:
       - dependency-name: "@wppconnect/wa-js"
       - dependency-name: "react"

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -4,6 +4,14 @@ on:
   pull_request:
     types:
       - opened
+      - synchronize
+      - reopened
+      - labeled
+      - unlabeled
+  check_suite:
+    types:
+      - completed
+  status: {}
 
 permissions:
   contents: write
@@ -21,5 +29,6 @@ jobs:
           MERGE_FILTER_AUTHOR: dependabot[bot]
           MERGE_LABELS: dependencies
           MERGE_METHOD: rebase
+          MERGE_READY_STATE: clean
           MERGE_FORKS: false
           MERGE_DELETE_BRANCH: true

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "speed-measure-webpack-plugin": "^1.5.0",
     "tailwindcss": "^4.3.1",
     "ts-loader": "^9.4.4",
-    "typescript": "~7.0.2",
+    "typescript": "~6.0.3",
     "webpack-cli": "^7.0.3",
     "webpack-merge": "^6.0.1"
   }


### PR DESCRIPTION
## Summary
- Reverts the Dependabot TypeScript major bump back to the supported 6.0.x line.
- Ignores future TypeScript semver-major updates until the current webpack/ts-loader toolchain supports them.
- Restricts Dependabot automerge to clean PRs and reruns automerge after checks finish, preventing merges while CI is pending or failing.

## Validation
- `npm install --package-lock=false`
- `npm run build`
- `git diff --check`

Root cause: PR #44 updated `typescript` from 6.0.3 to 7.0.2 and was merged by automerge before `Typecheck and build` finished; the check later failed with the same `ts-loader` `fileExists` crash seen in the scheduled `Update WA-JS` run.