### PR TITLE
fix: authenticate WA-JS release lookup

### DIFF
--- a/.github/workflows/update-wa-js.yml
+++ b/.github/workflows/update-wa-js.yml
@@ -21,6 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       WA_JS_VERSION: ${{ inputs.wa_js_version || 'latest' }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v7

--- a/scripts/download-wa-js-release.js
+++ b/scripts/download-wa-js-release.js
@@ -7,6 +7,7 @@ const assetName = 'wppconnect-wa.js';
 const requestedVersion = process.env.WA_JS_VERSION || 'latest';
 const skipDownload = /^(1|true|yes)$/i.test(process.env.WA_JS_SKIP_DOWNLOAD || '');
 const writeMetadata = /^(1|true|yes)$/i.test(process.env.WA_JS_WRITE_METADATA || '');
+const githubToken = process.env.GITHUB_TOKEN || process.env.GH_TOKEN || '';
 const target = path.join(
   __dirname,
   '..',
@@ -18,14 +19,24 @@ const target = path.join(
 );
 const metadataTarget = path.join(__dirname, '..', 'wa-js-release.json');
 
+function headersFor(url, options = {}) {
+  const headers = {
+    'User-Agent': 'wppconnect-extension-wa-js-updater',
+    Accept: 'application/vnd.github+json',
+    ...options.headers,
+  };
+
+  if (githubToken && new URL(url).hostname === 'api.github.com') {
+    headers.Authorization = `Bearer ${githubToken}`;
+  }
+
+  return headers;
+}
+
 function request(url, options = {}) {
   return new Promise((resolve, reject) => {
     const req = https.get(url, {
-      headers: {
-        'User-Agent': 'wppconnect-extension-wa-js-updater',
-        Accept: 'application/vnd.github+json',
-        ...options.headers,
-      },
+      headers: headersFor(url, options),
     }, (res) => {
       if ([301, 302, 303, 307, 308].includes(res.statusCode) && res.headers.location) {
         res.resume();


### PR DESCRIPTION
## Summary
- Uses `GITHUB_TOKEN`/`GH_TOKEN` when the WA-JS downloader queries the GitHub releases API.
- Exposes `GITHUB_TOKEN` to the Update WA-JS job so both the explicit download step and `npm run build` prebuild download are authenticated.

## Validation
- `GITHUB_TOKEN=$(gh auth token) WA_JS_WRITE_METADATA=true node scripts/download-wa-js-release.js`
- `GITHUB_TOKEN=$(gh auth token) npm run build`
- `git diff --check`

Root cause: scheduled run 29999999487 failed before build because `scripts/download-wa-js-release.js` queried `https://api.github.com/repos/wppconnect-team/wa-js/releases/latest` anonymously and hit the unauthenticated API rate limit.