### PR TITLE
fix: prevent concurrent release push races

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,6 +9,10 @@ on:
 permissions:
   contents: write
 
+concurrency:
+  group: release-main
+  cancel-in-progress: true
+
 jobs:
   release:
     name: Build and publish GitHub release
@@ -20,6 +24,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v7
         with:
+          ref: main
           fetch-depth: 0
 
       - name: Setup Node.js


### PR DESCRIPTION
## Summary
- coalesce concurrent release runs so stale pushes are cancelled
- check out the latest main branch before calculating and committing the release version

## Root cause
Multiple push-triggered release jobs ran from different event SHAs and attempted to push the same version commit. The first three were rejected as non-fast-forward after main advanced.

## Validation
- regression assertion for release concurrency and main checkout
- YAML parse
- git diff --check